### PR TITLE
Add room-based maze variant with full-screen rooms and edge transitions

### DIFF
--- a/app/src/app/app-routing.module.ts
+++ b/app/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { HomeComponent } from './home/home.component';
 import { MemoryComponent } from './memory/memory.component';
 import { SimonComponent } from './simon/simon.component';
 import { MazeComponent } from './maze/maze.component';
+import { MazeRoomsComponent } from './maze-rooms/maze-rooms.component';
 const routes: Routes = [
   { path: '', component: HomeComponent },
   {
@@ -21,6 +22,7 @@ const routes: Routes = [
   { path: 'memory', component: MemoryComponent },
   { path: 'simon', component: SimonComponent },
   { path: 'maze', component: MazeComponent },
+  { path: 'maze-rooms', component: MazeRoomsComponent },
   { path: '**', redirectTo: '' },
 ];
 

--- a/app/src/app/components/components.module.ts
+++ b/app/src/app/components/components.module.ts
@@ -13,6 +13,7 @@ import { HomeComponent } from "../home/home.component";
 import { MemoryComponent } from "../memory/memory.component";
 import { SimonComponent } from "../simon/simon.component";
 import { MazeComponent } from "../maze/maze.component";
+import { MazeRoomsComponent } from "../maze-rooms/maze-rooms.component";
 
 @NgModule({
   declarations: [
@@ -26,7 +27,8 @@ import { MazeComponent } from "../maze/maze.component";
     HomeComponent,
     MemoryComponent,
     SimonComponent,
-    MazeComponent
+    MazeComponent,
+    MazeRoomsComponent
   ],
   imports: [
     AppRoutingModule,

--- a/app/src/app/home/home.component.html
+++ b/app/src/app/home/home.component.html
@@ -45,5 +45,16 @@
         </div>
       </a>
     </div>
+    <div class="col-md-4">
+      <a routerLink="/maze-rooms" class="text-decoration-none text-dark">
+        <div class="card h-100 shadow-sm tile">
+          <div class="card-body text-center py-5">
+            <i class="bi bi-door-open-fill" style="font-size: 3rem;"></i>
+            <h2 class="card-title mt-3">Dungeon Maze - Kamers</h2>
+            <p class="card-text text-muted">Zoek je weg van kamer naar kamer, langs duivels en diamanten</p>
+          </div>
+        </div>
+      </a>
+    </div>
   </div>
 </div>

--- a/app/src/app/maze-rooms/maze-rooms.component.html
+++ b/app/src/app/maze-rooms/maze-rooms.component.html
@@ -1,0 +1,9 @@
+<div class="container-fluid py-4">
+  <div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Dungeon Maze - Kamers</h1>
+    <a routerLink="/" class="btn btn-outline-secondary btn-sm">Terug naar start</a>
+  </div>
+  <div class="maze-frame-wrap">
+    <iframe [src]="mazeUrl" title="Dungeon Maze - Kamers" class="maze-frame"></iframe>
+  </div>
+</div>

--- a/app/src/app/maze-rooms/maze-rooms.component.scss
+++ b/app/src/app/maze-rooms/maze-rooms.component.scss
@@ -1,0 +1,13 @@
+.maze-frame-wrap {
+  display: flex;
+  justify-content: center;
+}
+
+.maze-frame {
+  width: 100%;
+  max-width: 900px;
+  height: 80vh;
+  min-height: 600px;
+  border: none;
+  border-radius: 8px;
+}

--- a/app/src/app/maze-rooms/maze-rooms.component.ts
+++ b/app/src/app/maze-rooms/maze-rooms.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-maze-rooms',
+  templateUrl: './maze-rooms.component.html',
+  styleUrls: ['./maze-rooms.component.scss']
+})
+export class MazeRoomsComponent {
+  mazeUrl: SafeResourceUrl;
+
+  constructor(sanitizer: DomSanitizer) {
+    this.mazeUrl = sanitizer.bypassSecurityTrustResourceUrl('assets/maze-rooms/index.html');
+  }
+}

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -49,11 +49,10 @@
 
   const SPRITE_NAMES = [
     "hero_down", "hero_left", "hero_up", "hero_right",
-    "hero_down_walk", "hero_left_walk", "hero_up_walk", "hero_right_walk",
     "devil_down", "devil_left", "devil_up", "devil_right",
     "devil_down_walk", "devil_left_walk", "devil_up_walk", "devil_right_walk",
     "gem_blue", "gem_green", "gem_red", "gem_orange", "gem_white", "gem_pink",
-    "wall_block",
+    "wall_fill",
     "floor_plain", "floor_pebbles", "floor_rocks", "floor_grass",
     "floor_cracked1", "floor_cracked2", "floor_skull",
     "door", "key", "rock_small", "rock_big", "bone", "skull", "torch", "grass",
@@ -398,7 +397,7 @@
         if (room.grid[y][x] === FLOOR) {
           drawSprite(room.floorVariant[y][x], cx, cy, { fit: "cover" });
         } else {
-          drawSprite("wall_block", cx, cy, { fit: "cover" });
+          drawSprite("wall_fill", cx, cy, { fit: "cover" });
         }
       }
     }
@@ -428,7 +427,8 @@
     ].sort((a, b) => a.py - b.py);
 
     for (const e of entities) {
-      const walkFrame = e.moving && Math.floor(performance.now() / 150) % 2 === 0 ? "_walk" : "";
+      // devils have a walk-cycle frame; the hero sprite sheet only has static poses
+      const walkFrame = e.kind === "devil" && e.moving && Math.floor(performance.now() / 150) % 2 === 0 ? "_walk" : "";
       const blink = e.kind === "hero" && player.invulnUntil > performance.now() && Math.floor(performance.now() / 100) % 2 === 0;
       if (blink) continue;
       const sprite = `${e.kind === "hero" ? "hero" : "devil"}_${e.facing}${walkFrame}`;

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -209,6 +209,13 @@
     updateLabel();
   }
 
+  function setupOrientationHint() {
+    const hint = document.getElementById("orientation-hint");
+    document.getElementById("orientation-hint-close").addEventListener("click", () => {
+      hint.classList.add("dismissed");
+    });
+  }
+
   // ---------- room-graph (which rooms connect to which, and where) ----------
   function buildRoomGraph() {
     const n = RG_COLS * RG_ROWS;
@@ -926,7 +933,7 @@
       if (activePointerId !== null) return;
       if (gameOver || won) return;
       if (!overlay.classList.contains("hidden") || !helpOverlay.classList.contains("hidden")) return;
-      if (e.target.closest("#hud")) return;
+      if (e.target.closest("#hud") || e.target.closest("#orientation-hint")) return;
       activePointerId = e.pointerId;
       const rect = stage.getBoundingClientRect();
       originX = e.clientX - rect.left;
@@ -990,6 +997,7 @@
     setupFullscreen();
     setupJoystick();
     setupMute();
+    setupOrientationHint();
     await loadImages(SPRITE_NAMES);
     newLevel(0);
     setupHudSizing(); // after newLevel() so canvas.width/height reflect the real maze size

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -612,6 +612,7 @@
     W: "up", S: "down", A: "left", D: "right",
   };
   let queuedDir = null;
+  let touchDir = null;
 
   function handleDir(dir) {
     if (gameOver || won) return;
@@ -626,11 +627,6 @@
         handleDir(dir);
       }
     });
-    for (const btn of document.querySelectorAll("#dpad button")) {
-      const dir = btn.dataset.dir;
-      btn.addEventListener("touchstart", (e) => { e.preventDefault(); handleDir(dir); }, { passive: false });
-      btn.addEventListener("mousedown", () => handleDir(dir));
-    }
     document.getElementById("btn-new").addEventListener("click", () => {
       level = 1;
       score = 0;
@@ -650,12 +646,97 @@
     });
   }
 
+  // ---------- fullscreen ----------
+  function setupFullscreen() {
+    const btn = document.getElementById("btn-fullscreen");
+    const el = document.getElementById("game");
+    const request = el.requestFullscreen || el.webkitRequestFullscreen;
+    const exit = document.exitFullscreen || document.webkitExitFullscreen;
+    if (!request || !exit) {
+      btn.classList.add("hidden");
+      return;
+    }
+    const isFullscreen = () => Boolean(document.fullscreenElement || document.webkitFullscreenElement);
+    const updateLabel = () => {
+      btn.title = isFullscreen() ? "Verlaat fullscreen" : "Fullscreen";
+    };
+    btn.addEventListener("click", () => {
+      if (isFullscreen()) {
+        exit.call(document);
+      } else {
+        const result = request.call(el);
+        if (result && typeof result.catch === "function") result.catch(() => {});
+      }
+    });
+    document.addEventListener("fullscreenchange", updateLabel);
+    document.addEventListener("webkitfullscreenchange", updateLabel);
+    updateLabel();
+  }
+
+  // touch/mouse-drag joystick: touch anywhere on the stage and drag toward
+  // an edge to move that direction, for as long as the drag stays deflected.
+  function setupJoystick() {
+    const stage = document.getElementById("stage");
+    const joystick = document.getElementById("joystick");
+    const knob = document.getElementById("joystick-knob");
+    const overlay = document.getElementById("overlay");
+    const MAX_RADIUS = 40;
+    const DEAD_ZONE = 12;
+
+    let activePointerId = null;
+    let originX = 0, originY = 0;
+
+    function dirFromDelta(dx, dy) {
+      if (Math.hypot(dx, dy) < DEAD_ZONE) return null;
+      return Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? "right" : "left") : (dy > 0 ? "down" : "up");
+    }
+
+    stage.addEventListener("pointerdown", (e) => {
+      if (activePointerId !== null) return;
+      if (gameOver || won) return;
+      if (!overlay.classList.contains("hidden")) return;
+      if (e.target.closest("#hud")) return;
+      activePointerId = e.pointerId;
+      const rect = stage.getBoundingClientRect();
+      originX = e.clientX - rect.left;
+      originY = e.clientY - rect.top;
+      joystick.style.left = `${originX}px`;
+      joystick.style.top = `${originY}px`;
+      knob.style.transform = "translate(0, 0)";
+      joystick.classList.remove("hidden");
+      stage.setPointerCapture(e.pointerId);
+    });
+
+    stage.addEventListener("pointermove", (e) => {
+      if (e.pointerId !== activePointerId) return;
+      const rect = stage.getBoundingClientRect();
+      const dx = e.clientX - rect.left - originX;
+      const dy = e.clientY - rect.top - originY;
+      const dist = Math.min(MAX_RADIUS, Math.hypot(dx, dy));
+      const angle = Math.atan2(dy, dx);
+      knob.style.transform = `translate(${Math.cos(angle) * dist}px, ${Math.sin(angle) * dist}px)`;
+      touchDir = dirFromDelta(dx, dy);
+    });
+
+    function release(e) {
+      if (e.pointerId !== activePointerId) return;
+      activePointerId = null;
+      touchDir = null;
+      joystick.classList.add("hidden");
+    }
+    stage.addEventListener("pointerup", release);
+    stage.addEventListener("pointercancel", release);
+  }
+
   // ---------- main loop ----------
   function loop(now) {
     if (!gameOver && !won) {
       if (queuedDir && !player.moving) {
         tryMove(player, queuedDir);
         queuedDir = null;
+      }
+      if (touchDir && !player.moving) {
+        tryMove(player, touchDir);
       }
       updateMovement(player, PLAYER_MOVE_MS, now);
       for (const e of activeRoom.devils) updateMovement(e, ENEMY_MOVE_MS * 0.9, now);
@@ -678,6 +759,8 @@
     ctx = canvas.getContext("2d");
     ctx.imageSmoothingEnabled = false;
     setupInput();
+    setupFullscreen();
+    setupJoystick();
     await loadImages(SPRITE_NAMES);
     newLevel(0);
     requestAnimationFrame(loop);

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -19,12 +19,35 @@
   const WALL = 0;
   const FLOOR = 1;
 
+  // 4-directional: used for enemy pathing/AI, which only has 4-way sprites
   const DIRS = {
     up: { dx: 0, dy: -1 },
     down: { dx: 0, dy: 1 },
     left: { dx: -1, dy: 0 },
     right: { dx: 1, dy: 0 },
   };
+
+  // the player can also move diagonally; these are only looked up by
+  // tryMove(), never fed into bfs()/enemyStep() which stay 4-directional
+  const DIAGONAL_DIRS = {
+    "up-left": { dx: -1, dy: -1 },
+    "up-right": { dx: 1, dy: -1 },
+    "down-left": { dx: -1, dy: 1 },
+    "down-right": { dx: 1, dy: 1 },
+  };
+  const ALL_DIRS = { ...DIRS, ...DIAGONAL_DIRS };
+
+  // the sprite sheet only has down/left/up/right poses, so a diagonal move
+  // faces (and animates) as a horizontal run in the matching direction
+  const DIAGONAL_FACING = {
+    "up-left": "left", "down-left": "left",
+    "up-right": "right", "down-right": "right",
+  };
+
+  // the source sheet's "walk" row is 4 frames of a rightward run cycle;
+  // mirror them for left, and fall back to the static pose for up/down.
+  const HERO_RUN_FRAMES = ["hero_run0", "hero_run1", "hero_run2", "hero_run3"];
+  const HERO_RUN_FRAME_MS = 110;
 
   const GEM_TYPES = [
     { name: "gem_blue", value: 10, weight: 30 },
@@ -49,6 +72,7 @@
 
   const SPRITE_NAMES = [
     "hero_down", "hero_left", "hero_up", "hero_right",
+    "hero_run0", "hero_run1", "hero_run2", "hero_run3",
     "devil_down", "devil_left", "devil_up", "devil_right",
     "devil_down_walk", "devil_left_walk", "devil_up_walk", "devil_right_walk",
     "gem_blue", "gem_green", "gem_red", "gem_orange", "gem_white", "gem_pink",
@@ -427,35 +451,60 @@
     ].sort((a, b) => a.py - b.py);
 
     for (const e of entities) {
-      // devils have a walk-cycle frame; the hero sprite sheet only has static poses
-      const walkFrame = e.kind === "devil" && e.moving && Math.floor(performance.now() / 150) % 2 === 0 ? "_walk" : "";
       const blink = e.kind === "hero" && player.invulnUntil > performance.now() && Math.floor(performance.now() / 100) % 2 === 0;
       if (blink) continue;
-      const sprite = `${e.kind === "hero" ? "hero" : "devil"}_${e.facing}${walkFrame}`;
-      drawSpritePixel(sprite, e.px, e.py);
+      if (e.kind === "hero") {
+        drawHero(e);
+      } else {
+        // devils have a walk-cycle frame; the hero sprite sheet only has static poses
+        const walkFrame = e.moving && Math.floor(performance.now() / 150) % 2 === 0 ? "_walk" : "";
+        drawSpritePixel(`devil_${e.facing}${walkFrame}`, e.px, e.py);
+      }
     }
   }
 
-  function drawSpritePixel(name, px, py) {
+  function drawHero(e) {
+    if (e.moving && (e.facing === "left" || e.facing === "right")) {
+      const frame = HERO_RUN_FRAMES[Math.floor(performance.now() / HERO_RUN_FRAME_MS) % HERO_RUN_FRAMES.length];
+      drawSpritePixel(frame, e.px, e.py, e.facing === "left");
+    } else {
+      drawSpritePixel(`hero_${e.facing}`, e.px, e.py);
+    }
+  }
+
+  function drawSpritePixel(name, px, py, mirror = false) {
     const img = images[name];
     if (!img || !img.complete || img.naturalWidth === 0) return;
     const w = TILE;
     const ratio = img.naturalHeight / img.naturalWidth;
     const h = w * ratio;
-    const dx = px;
     const dy = py + TILE - h;
-    ctx.drawImage(img, dx, dy, w, h);
+    if (mirror) {
+      ctx.save();
+      ctx.translate(px + w, dy);
+      ctx.scale(-1, 1);
+      ctx.drawImage(img, 0, 0, w, h);
+      ctx.restore();
+    } else {
+      ctx.drawImage(img, px, dy, w, h);
+    }
   }
 
   // ---------- movement ----------
   function tryMove(entity, dir) {
     if (entity.moving) return false;
-    const d = DIRS[dir];
+    const d = ALL_DIRS[dir];
+    if (!d) return false;
     const nx = entity.x + d.dx;
     const ny = entity.y + d.dy;
     if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) return false;
     if (activeRoom.grid[ny][nx] !== FLOOR) return false;
-    entity.facing = dir;
+    if (d.dx !== 0 && d.dy !== 0) {
+      // don't let a diagonal move cut through a solid corner
+      const orthoBlocked = activeRoom.grid[entity.y][nx] !== FLOOR && activeRoom.grid[ny][entity.x] !== FLOOR;
+      if (orthoBlocked) return false;
+    }
+    entity.facing = DIAGONAL_FACING[dir] || dir;
     entity.from = { x: entity.x, y: entity.y };
     entity.x = nx;
     entity.y = ny;
@@ -611,12 +660,17 @@
     w: "up", s: "down", a: "left", d: "right",
     W: "up", S: "down", A: "left", D: "right",
   };
-  let queuedDir = null;
+  // held (not just pressed) so opposite/adjacent keys combine into diagonals
+  const heldDirs = new Set();
   let touchDir = null;
 
-  function handleDir(dir) {
-    if (gameOver || won) return;
-    queuedDir = dir;
+  function keyboardDir() {
+    const dy = (heldDirs.has("down") ? 1 : 0) - (heldDirs.has("up") ? 1 : 0);
+    const dx = (heldDirs.has("right") ? 1 : 0) - (heldDirs.has("left") ? 1 : 0);
+    if (dx === 0 && dy === 0) return null;
+    if (dx === 0) return dy > 0 ? "down" : "up";
+    if (dy === 0) return dx > 0 ? "right" : "left";
+    return `${dy > 0 ? "down" : "up"}-${dx > 0 ? "right" : "left"}`;
   }
 
   function setupInput() {
@@ -624,9 +678,14 @@
       const dir = KEY_DIR[e.key];
       if (dir) {
         e.preventDefault();
-        handleDir(dir);
+        heldDirs.add(dir);
       }
     });
+    window.addEventListener("keyup", (e) => {
+      const dir = KEY_DIR[e.key];
+      if (dir) heldDirs.delete(dir);
+    });
+    window.addEventListener("blur", () => heldDirs.clear());
     document.getElementById("btn-new").addEventListener("click", () => {
       level = 1;
       score = 0;
@@ -764,9 +823,12 @@
     let activePointerId = null;
     let originX = 0, originY = 0;
 
+    // snap the drag angle to one of 8 directions (4 cardinal + 4 diagonal)
+    const OCTANT_DIRS = ["right", "down-right", "down", "down-left", "left", "up-left", "up", "up-right"];
     function dirFromDelta(dx, dy) {
       if (Math.hypot(dx, dy) < DEAD_ZONE) return null;
-      return Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? "right" : "left") : (dy > 0 ? "down" : "up");
+      const octant = Math.round(Math.atan2(dy, dx) / (Math.PI / 4));
+      return OCTANT_DIRS[((octant % 8) + 8) % 8];
     }
 
     stage.addEventListener("pointerdown", (e) => {
@@ -809,12 +871,9 @@
   // ---------- main loop ----------
   function loop(now) {
     if (!gameOver && !won) {
-      if (queuedDir && !player.moving) {
-        tryMove(player, queuedDir);
-        queuedDir = null;
-      }
-      if (touchDir && !player.moving) {
-        tryMove(player, touchDir);
+      if (!player.moving) {
+        const dir = keyboardDir() || touchDir;
+        if (dir) tryMove(player, dir);
       }
       updateMovement(player, PLAYER_MOVE_MS, now);
       for (const e of activeRoom.devils) updateMovement(e, ENEMY_MOVE_MS * 0.9, now);

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -2,22 +2,19 @@
   "use strict";
 
   // ---------- config ----------
-  const TILE = 34;
+  const TILE = 40;
   const ENEMY_MOVE_MS = 450;
   const PLAYER_MOVE_MS = 130;
   const INVULN_MS = 1200;
 
-  // room-grid layout: the map is a grid of "slots", each slot hosts one
-  // rectangular room. Rooms are connected to their N/S/E/W neighbours
-  // through short corridors so that "kamers grenzen aan elkaar".
-  const RG_COLS = 4;
-  const RG_ROWS = 3;
-  const SLOT_W = 7; // interior tile width of a slot
-  const SLOT_H = 6; // interior tile height of a slot
-  const EXTRA_CONNECTION_CHANCE = 0.4; // chance a non-tree edge also gets a doorway (loops, extra exits)
-
-  const COLS = RG_COLS * (SLOT_W + 1) + 1;
-  const ROWS = RG_ROWS * (SLOT_H + 1) + 1;
+  // each room fills the whole screen; walking off the edge of the screen
+  // through an exit takes you to the neighbouring room in that direction.
+  const COLS = 19; // tiles per room, full screen width
+  const ROWS = 13; // tiles per room, full screen height
+  const RG_COLS = 4; // rooms across the world
+  const RG_ROWS = 3; // rooms down the world
+  const DOOR_WIDTH = 3; // width (in tiles) of an exit opening
+  const EXTRA_CONNECTION_CHANCE = 0.4; // chance a non-tree edge also becomes an exit (loops, extra exits)
 
   const WALL = 0;
   const FLOOR = 1;
@@ -84,6 +81,10 @@
     return arr;
   }
 
+  function randInt(minInclusive, maxInclusive) {
+    return minInclusive + Math.floor(Math.random() * (maxInclusive - minInclusive + 1));
+  }
+
   function key2(x, y) { return `${x},${y}`; }
 
   // ---------- asset loading ----------
@@ -103,59 +104,8 @@
     );
   }
 
-  // ---------- room-based maze generation ----------
-  function slotX0(rx) { return 1 + rx * (SLOT_W + 1); }
-  function slotX1(rx) { return slotX0(rx) + SLOT_W - 1; }
-  function slotY0(ry) { return 1 + ry * (SLOT_H + 1); }
-  function slotY1(ry) { return slotY0(ry) + SLOT_H - 1; }
-  function centerCol(rx) { return slotX0(rx) + Math.floor((SLOT_W - 1) / 2); }
-  function centerRow(ry) { return slotY0(ry) + Math.floor((SLOT_H - 1) / 2); }
-
-  // a room is a fairly open rectangle, randomly sized, but always
-  // containing its slot's center row/column so neighbouring rooms can
-  // always be joined by a straight corridor at that row/column.
-  function makeRoomRect(rx, ry) {
-    const sx0 = slotX0(rx), sx1 = slotX1(rx);
-    const sy0 = slotY0(ry), sy1 = slotY1(ry);
-    const cc = centerCol(rx), cr = centerRow(ry);
-
-    const w = 3 + Math.floor(Math.random() * 3); // 3..5
-    const h = 3 + Math.floor(Math.random() * 2); // 3..4
-
-    let x0 = cc - Math.floor(Math.random() * w);
-    x0 = Math.max(sx0, Math.min(x0, sx1 - w + 1));
-    let x1 = Math.min(sx1, x0 + w - 1);
-    if (cc < x0) x0 = cc;
-    if (cc > x1) x1 = cc;
-
-    let y0 = cr - Math.floor(Math.random() * h);
-    y0 = Math.max(sy0, Math.min(y0, sy1 - h + 1));
-    let y1 = Math.min(sy1, y0 + h - 1);
-    if (cr < y0) y0 = cr;
-    if (cr > y1) y1 = cr;
-
-    return { x0, y0, x1, y1, rx, ry, exits: [] };
-  }
-
-  function generateMaze() {
-    const grid = Array.from({ length: ROWS }, () => Array(COLS).fill(WALL));
-
-    const rooms = [];
-    for (let ry = 0; ry < RG_ROWS; ry++) {
-      const row = [];
-      for (let rx = 0; rx < RG_COLS; rx++) row.push(makeRoomRect(rx, ry));
-      rooms.push(row);
-    }
-
-    for (const row of rooms) {
-      for (const r of row) {
-        for (let y = r.y0; y <= r.y1; y++) {
-          for (let x = r.x0; x <= r.x1; x++) grid[y][x] = FLOOR;
-        }
-      }
-    }
-
-    // union-find over the room grid, to guarantee full connectivity
+  // ---------- room-graph (which rooms connect to which, and where) ----------
+  function buildRoomGraph() {
     const n = RG_COLS * RG_ROWS;
     const parent = Array.from({ length: n }, (_, i) => i);
     function find(i) { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; } return i; }
@@ -183,24 +133,185 @@
     const extraCount = Math.floor(leftover.length * EXTRA_CONNECTION_CHANCE);
     for (let i = 0; i < extraCount; i++) connections.push(leftover[i]);
 
+    // exits[ry][rx] = { north, south, east, west }, each either null or a
+    // [start, end] tile range on that wall where the room is open.
+    const exits = Array.from({ length: RG_ROWS }, () =>
+      Array.from({ length: RG_COLS }, () => ({ north: null, south: null, east: null, west: null }))
+    );
+
     for (const e of connections) {
-      const roomA = rooms[e.a.ry][e.a.rx];
-      const roomB = rooms[e.b.ry][e.b.rx];
       if (e.axis === "h") {
-        const row = centerRow(e.a.ry);
-        for (let x = roomA.x1 + 1; x <= roomB.x0 - 1; x++) grid[row][x] = FLOOR;
-        roomA.exits.push("east");
-        roomB.exits.push("west");
+        const rowStart = randInt(1, ROWS - 1 - DOOR_WIDTH);
+        const range = [rowStart, rowStart + DOOR_WIDTH - 1];
+        exits[e.a.ry][e.a.rx].east = range;
+        exits[e.b.ry][e.b.rx].west = range;
       } else {
-        const col = centerCol(e.a.rx);
-        for (let y = roomA.y1 + 1; y <= roomB.y0 - 1; y++) grid[y][col] = FLOOR;
-        roomA.exits.push("south");
-        roomB.exits.push("north");
+        const colStart = randInt(1, COLS - 1 - DOOR_WIDTH);
+        const range = [colStart, colStart + DOOR_WIDTH - 1];
+        exits[e.a.ry][e.a.rx].south = range;
+        exits[e.b.ry][e.b.rx].north = range;
       }
     }
 
-    const start = { x: centerCol(0), y: centerRow(0) };
-    return { grid, start };
+    return { exits, connections };
+  }
+
+  function roomGraphBFS(sx, sy, connections) {
+    const adj = new Map();
+    function addAdj(a, b) {
+      const ka = key2(a.rx, a.ry), kb = key2(b.rx, b.ry);
+      if (!adj.has(ka)) adj.set(ka, []);
+      if (!adj.has(kb)) adj.set(kb, []);
+      adj.get(ka).push(b);
+      adj.get(kb).push(a);
+    }
+    for (const e of connections) addAdj(e.a, e.b);
+
+    const dist = Array.from({ length: RG_ROWS }, () => Array(RG_COLS).fill(-1));
+    dist[sy][sx] = 0;
+    const queue = [[sx, sy]];
+    let head = 0;
+    while (head < queue.length) {
+      const [cx, cy] = queue[head++];
+      const neighbours = adj.get(key2(cx, cy)) || [];
+      for (const nb of neighbours) {
+        if (dist[nb.ry][nb.rx] === -1) {
+          dist[nb.ry][nb.rx] = dist[cy][cx] + 1;
+          queue.push([nb.rx, nb.ry]);
+        }
+      }
+    }
+    return dist;
+  }
+
+  // ---------- a single room's tile grid ----------
+  function buildRoomGrid(roomExits) {
+    const grid = Array.from({ length: ROWS }, () => Array(COLS).fill(WALL));
+    for (let y = 1; y <= ROWS - 2; y++) {
+      for (let x = 1; x <= COLS - 2; x++) grid[y][x] = FLOOR;
+    }
+    if (roomExits.north) { const [c0, c1] = roomExits.north; for (let x = c0; x <= c1; x++) grid[0][x] = FLOOR; }
+    if (roomExits.south) { const [c0, c1] = roomExits.south; for (let x = c0; x <= c1; x++) grid[ROWS - 1][x] = FLOOR; }
+    if (roomExits.west) { const [r0, r1] = roomExits.west; for (let y = r0; y <= r1; y++) grid[y][0] = FLOOR; }
+    if (roomExits.east) { const [r0, r1] = roomExits.east; for (let y = r0; y <= r1; y++) grid[y][COLS - 1] = FLOOR; }
+    return grid;
+  }
+
+  // ---------- full world generation ----------
+  function generateWorld() {
+    const { exits, connections } = buildRoomGraph();
+
+    const rooms = [];
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      const row = [];
+      for (let rx = 0; rx < RG_COLS; rx++) {
+        const grid = buildRoomGrid(exits[ry][rx]);
+        const floorVariant = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+        const decor = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+        for (let y = 0; y < ROWS; y++) {
+          for (let x = 0; x < COLS; x++) {
+            if (grid[y][x] === FLOOR) floorVariant[y][x] = pickWeighted(FLOOR_VARIANTS).name;
+          }
+        }
+        row.push({
+          rx, ry, grid, floorVariant, decor, exits: exits[ry][rx],
+          gems: [], devils: [],
+          hasDoor: false, doorPos: null,
+          hasKey: false, keyPos: null, keyCollected: false,
+          usedTiles: new Set(),
+        });
+      }
+      rooms.push(row);
+    }
+
+    function claimTile(room, x, y) { room.usedTiles.add(key2(x, y)); }
+    function interiorCandidates(room) {
+      const list = [];
+      for (let y = 1; y <= ROWS - 2; y++) {
+        for (let x = 1; x <= COLS - 2; x++) {
+          if (!room.usedTiles.has(key2(x, y))) list.push({ x, y });
+        }
+      }
+      return list;
+    }
+
+    const startPos = { x: Math.floor(COLS / 2), y: Math.floor(ROWS / 2) };
+    const startRoom = rooms[0][0];
+    claimTile(startRoom, startPos.x, startPos.y);
+
+    const roomDist = roomGraphBFS(0, 0, connections);
+    let maxDist = 0, doorRoomCoord = { rx: 0, ry: 0 };
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      for (let rx = 0; rx < RG_COLS; rx++) {
+        if (roomDist[ry][rx] > maxDist) { maxDist = roomDist[ry][rx]; doorRoomCoord = { rx, ry }; }
+      }
+    }
+
+    const doorRoom = rooms[doorRoomCoord.ry][doorRoomCoord.rx];
+    {
+      const cands = interiorCandidates(doorRoom);
+      const c = cands.length ? cands[Math.floor(Math.random() * cands.length)] : startPos;
+      doorRoom.hasDoor = true;
+      doorRoom.doorPos = { x: c.x, y: c.y };
+      claimTile(doorRoom, c.x, c.y);
+    }
+
+    // key: in a room roughly 40%-80% of the way to the door, so it can't
+    // be grabbed on the way in without exploring.
+    const keyRoomCandidates = [];
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      for (let rx = 0; rx < RG_COLS; rx++) {
+        if (rx === doorRoomCoord.rx && ry === doorRoomCoord.ry) continue;
+        const d = roomDist[ry][rx];
+        if (d >= Math.ceil(maxDist * 0.4) && d <= Math.ceil(maxDist * 0.8)) keyRoomCandidates.push(rooms[ry][rx]);
+      }
+    }
+    const keyRoom = keyRoomCandidates.length
+      ? keyRoomCandidates[Math.floor(Math.random() * keyRoomCandidates.length)]
+      : startRoom;
+    {
+      const cands = interiorCandidates(keyRoom);
+      const c = cands.length ? cands[Math.floor(Math.random() * cands.length)] : startPos;
+      keyRoom.hasKey = true;
+      keyRoom.keyPos = { x: c.x, y: c.y };
+      claimTile(keyRoom, c.x, c.y);
+    }
+
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      for (let rx = 0; rx < RG_COLS; rx++) {
+        const room = rooms[ry][rx];
+        const isStart = rx === 0 && ry === 0;
+
+        const cands = interiorCandidates(room);
+        shuffle(cands);
+
+        const decorCount = Math.min(10, cands.length);
+        const decorSlice = cands.slice(0, decorCount);
+        for (const c of decorSlice) room.decor[c.y][c.x] = DECOR_PROPS[Math.floor(Math.random() * DECOR_PROPS.length)];
+
+        const rest = cands.slice(decorCount);
+        const gemCount = Math.min(randInt(2, 5), rest.length);
+        const gemSlice = rest.slice(0, gemCount);
+        for (const c of gemSlice) {
+          const type = pickWeighted(GEM_TYPES);
+          room.gems.push({ x: c.x, y: c.y, type: type.name, value: type.value, collected: false });
+        }
+
+        const rest2 = rest.slice(gemCount);
+        const devilBase = isStart ? 0 : Math.min(4, 1 + Math.floor(roomDist[ry][rx] / 2));
+        const devilCount = Math.min(devilBase, rest2.length);
+        const devilSlice = rest2.slice(0, devilCount);
+        for (const c of devilSlice) {
+          room.devils.push({
+            x: c.x, y: c.y,
+            px: c.x * TILE, py: c.y * TILE,
+            facing: "down", moving: false, moveStart: 0, from: { x: c.x, y: c.y },
+          });
+        }
+      }
+    }
+
+    return { rooms, connections, doorRoomCoord, startPos };
   }
 
   function bfs(grid, sx, sy) {
@@ -225,110 +336,22 @@
 
   // ---------- game state ----------
   let canvas, ctx;
-  let grid, floorVariant, decor;
-  let start, door, keyItem, gems, enemies;
+  let world, activeRoom, curRx, curRy;
   let player;
   let score = 0, lives = 3, level = 1;
   let gameOver = false, won = false;
   let lastEnemyTick = 0;
-  let usedCells;
-
-  function farthestCell(dist) {
-    let best = { x: 1, y: 1, d: -1 };
-    for (let y = 0; y < ROWS; y++) {
-      for (let x = 0; x < COLS; x++) {
-        if (dist[y][x] > best.d) best = { x, y, d: dist[y][x] };
-      }
-    }
-    return best;
-  }
-
-  function floorCells(dist, minDist = 0) {
-    const cells = [];
-    for (let y = 0; y < ROWS; y++) {
-      for (let x = 0; x < COLS; x++) {
-        if (dist[y][x] >= minDist) cells.push({ x, y, d: dist[y][x] });
-      }
-    }
-    return cells;
-  }
-
-  function claim(x, y) {
-    usedCells.add(key2(x, y));
-  }
-  function isFree(x, y) {
-    return !usedCells.has(key2(x, y));
-  }
 
   function newLevel(carryScore) {
-    const generated = generateMaze();
-    grid = generated.grid;
-    start = generated.start;
-    usedCells = new Set();
-    claim(start.x, start.y);
-
-    const dist = bfs(grid, start.x, start.y);
-    const far = farthestCell(dist);
-    door = { x: far.x, y: far.y, locked: true };
-    claim(door.x, door.y);
-
-    // key: somewhere between 40%-75% of max distance from start
-    const candidates = floorCells(dist, Math.floor(far.d * 0.4)).filter(
-      (c) => c.d <= far.d * 0.8 && isFree(c.x, c.y)
-    );
-    const keyCell = candidates.length
-      ? candidates[Math.floor(Math.random() * candidates.length)]
-      : { x: start.x, y: start.y };
-    keyItem = { x: keyCell.x, y: keyCell.y, collected: false };
-    claim(keyItem.x, keyItem.y);
-
-    // floor texture + decorations per cell
-    floorVariant = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
-    decor = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
-    for (let y = 0; y < ROWS; y++) {
-      for (let x = 0; x < COLS; x++) {
-        if (grid[y][x] === FLOOR) {
-          floorVariant[y][x] = pickWeighted(FLOOR_VARIANTS).name;
-        }
-      }
-    }
-    const allFloor = floorCells(dist).filter((c) => isFree(c.x, c.y));
-    shuffle(allFloor);
-    const decorCount = Math.min(30, allFloor.length);
-    for (let i = 0; i < decorCount; i++) {
-      const c = allFloor[i];
-      decor[c.y][c.x] = DECOR_PROPS[Math.floor(Math.random() * DECOR_PROPS.length)];
-    }
-
-    // gems (diamanten), spread across the rooms
-    gems = [];
-    const gemCandidates = allFloor.slice(decorCount, decorCount + 70);
-    const gemCount = Math.min(18 + level * 2, gemCandidates.length);
-    for (let i = 0; i < gemCount; i++) {
-      const c = gemCandidates[i];
-      const type = pickWeighted(GEM_TYPES);
-      gems.push({ x: c.x, y: c.y, type: type.name, value: type.value, collected: false });
-      claim(c.x, c.y);
-    }
-
-    // devils: spawn reasonably far from the player
-    enemies = [];
-    const enemySpots = floorCells(dist, Math.floor(far.d * 0.3)).filter((c) => isFree(c.x, c.y));
-    shuffle(enemySpots);
-    const enemyCount = Math.min(3 + level, 10, enemySpots.length);
-    for (let i = 0; i < enemyCount; i++) {
-      const c = enemySpots[i];
-      enemies.push({
-        x: c.x, y: c.y,
-        px: c.x * TILE, py: c.y * TILE,
-        facing: "down", moving: false, moveStart: 0, from: { x: c.x, y: c.y },
-      });
-    }
+    world = generateWorld();
+    curRx = 0;
+    curRy = 0;
+    activeRoom = world.rooms[curRy][curRx];
 
     player = {
-      x: start.x, y: start.y,
-      px: start.x * TILE, py: start.y * TILE,
-      facing: "down", moving: false, moveStart: 0, from: { x: start.x, y: start.y },
+      x: world.startPos.x, y: world.startPos.y,
+      px: world.startPos.x * TILE, py: world.startPos.y * TILE,
+      facing: "down", moving: false, moveStart: 0, from: { x: world.startPos.x, y: world.startPos.y },
       invulnUntil: 0,
       hasKey: false,
     };
@@ -366,40 +389,41 @@
 
   function render() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const room = activeRoom;
 
     // floor + walls
     for (let y = 0; y < ROWS; y++) {
       for (let x = 0; x < COLS; x++) {
         const cx = x * TILE, cy = y * TILE;
-        if (grid[y][x] === FLOOR) {
-          drawSprite(floorVariant[y][x], cx, cy, { fit: "cover" });
+        if (room.grid[y][x] === FLOOR) {
+          drawSprite(room.floorVariant[y][x], cx, cy, { fit: "cover" });
         } else {
           drawSprite("wall_block", cx, cy, { fit: "cover" });
         }
       }
     }
 
-    // decorations (flush on floor, no bottom anchor needed for small props)
+    // decorations
     for (let y = 0; y < ROWS; y++) {
       for (let x = 0; x < COLS; x++) {
-        if (decor[y][x]) {
-          drawSprite(decor[y][x], x * TILE, y * TILE, { fit: "contain-center", scale: 0.7 });
+        if (room.decor[y][x]) {
+          drawSprite(room.decor[y][x], x * TILE, y * TILE, { fit: "contain-center", scale: 0.7 });
         }
       }
     }
 
     // key + door
-    if (!keyItem.collected) drawSprite("key", keyItem.x * TILE, keyItem.y * TILE, { scale: 0.7 });
-    drawSprite("door", door.x * TILE, door.y * TILE, { scale: 0.95 });
+    if (room.hasKey && !room.keyCollected) drawSprite("key", room.keyPos.x * TILE, room.keyPos.y * TILE, { scale: 0.7 });
+    if (room.hasDoor) drawSprite("door", room.doorPos.x * TILE, room.doorPos.y * TILE, { scale: 0.95 });
 
     // gems
-    for (const g of gems) {
+    for (const g of room.gems) {
       if (!g.collected) drawSprite(g.type, g.x * TILE, g.y * TILE, { scale: 0.65 });
     }
 
     // entities sorted by row for pseudo depth
     const entities = [
-      ...enemies.map((e) => ({ ...e, kind: "devil" })),
+      ...room.devils.map((e) => ({ ...e, kind: "devil" })),
       { ...player, kind: "hero" },
     ].sort((a, b) => a.py - b.py);
 
@@ -430,7 +454,7 @@
     const nx = entity.x + d.dx;
     const ny = entity.y + d.dy;
     if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) return false;
-    if (grid[ny][nx] !== FLOOR) return false;
+    if (activeRoom.grid[ny][nx] !== FLOOR) return false;
     entity.facing = dir;
     entity.from = { x: entity.x, y: entity.y };
     entity.x = nx;
@@ -453,16 +477,15 @@
   }
 
   function enemyStep(enemy) {
-    const dist = bfs(grid, player.x, player.y);
+    const dist = bfs(activeRoom.grid, player.x, player.y);
     const d = dist[enemy.y][enemy.x];
     let dir = null;
     if (d !== -1 && d <= 9 && Math.random() < 0.7) {
-      // step toward player: find neighbor with smaller distance
       let best = null, bestD = d;
       for (const [name, vec] of Object.entries(DIRS)) {
         const nx = enemy.x + vec.dx, ny = enemy.y + vec.dy;
         if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) continue;
-        if (grid[ny][nx] !== FLOOR) continue;
+        if (activeRoom.grid[ny][nx] !== FLOOR) continue;
         if (dist[ny][nx] !== -1 && dist[ny][nx] < bestD) {
           bestD = dist[ny][nx];
           best = name;
@@ -474,39 +497,72 @@
       const options = Object.keys(DIRS).filter((name) => {
         const vec = DIRS[name];
         const nx = enemy.x + vec.dx, ny = enemy.y + vec.dy;
-        return nx >= 0 && ny >= 0 && nx < COLS && ny < ROWS && grid[ny][nx] === FLOOR;
+        return nx >= 0 && ny >= 0 && nx < COLS && ny < ROWS && activeRoom.grid[ny][nx] === FLOOR;
       });
       if (options.length) dir = options[Math.floor(Math.random() * options.length)];
     }
     if (dir) tryMove(enemy, dir);
   }
 
+  // ---------- room transitions ----------
+  function transitionRoom() {
+    let dir = null;
+    if (player.x === COLS - 1) dir = "east";
+    else if (player.x === 0) dir = "west";
+    else if (player.y === ROWS - 1) dir = "south";
+    else if (player.y === 0) dir = "north";
+    if (!dir) return;
+
+    let nrx = curRx, nry = curRy;
+    if (dir === "east") nrx++;
+    else if (dir === "west") nrx--;
+    else if (dir === "south") nry++;
+    else nry--;
+    if (nrx < 0 || nrx >= RG_COLS || nry < 0 || nry >= RG_ROWS) return;
+
+    curRx = nrx;
+    curRy = nry;
+    activeRoom = world.rooms[curRy][curRx];
+
+    if (dir === "east") player.x = 1;
+    else if (dir === "west") player.x = COLS - 2;
+    else if (dir === "south") player.y = 1;
+    else player.y = ROWS - 2;
+
+    player.px = player.x * TILE;
+    player.py = player.y * TILE;
+    player.moving = false;
+    updateHud();
+  }
+
   function checkCollisions() {
-    if (!keyItem.collected && player.x === keyItem.x && player.y === keyItem.y) {
-      keyItem.collected = true;
+    const room = activeRoom;
+    if (room.hasKey && !room.keyCollected && player.x === room.keyPos.x && player.y === room.keyPos.y) {
+      room.keyCollected = true;
       player.hasKey = true;
       updateHud();
     }
-    for (const g of gems) {
+    for (const g of room.gems) {
       if (!g.collected && player.x === g.x && player.y === g.y) {
         g.collected = true;
         score += g.value;
         updateHud();
       }
     }
-    if (player.x === door.x && player.y === door.y) {
-      if (player.hasKey) {
-        won = true;
-        showOverlay("Level voltooid!", `Je hebt de deur bereikt met ${score} punten.`, "Volgende level");
-      }
+    if (room.hasDoor && player.x === room.doorPos.x && player.y === room.doorPos.y && player.hasKey) {
+      won = true;
+      showOverlay("Level voltooid!", `Je hebt de deur bereikt met ${score} punten.`, "Volgende level");
     }
     if (player.invulnUntil <= performance.now()) {
-      for (const e of enemies) {
+      for (const e of room.devils) {
         if (e.x === player.x && e.y === player.y) {
           hitPlayer();
           break;
         }
       }
+    }
+    if (!player.moving && (player.x === 0 || player.x === COLS - 1 || player.y === 0 || player.y === ROWS - 1)) {
+      transitionRoom();
     }
   }
 
@@ -518,11 +574,15 @@
       gameOver = true;
       showOverlay("Game Over", `Je werd gepakt door een duivel. Score: ${score}`, "Opnieuw beginnen");
     } else {
-      player.x = start.x;
-      player.y = start.y;
-      player.px = start.x * TILE;
-      player.py = start.y * TILE;
+      curRx = 0;
+      curRy = 0;
+      activeRoom = world.rooms[0][0];
+      player.x = world.startPos.x;
+      player.y = world.startPos.y;
+      player.px = player.x * TILE;
+      player.py = player.y * TILE;
       player.moving = false;
+      updateHud();
     }
   }
 
@@ -532,6 +592,7 @@
     document.getElementById("key-state").textContent = player && player.hasKey ? "✔" : "?";
     document.getElementById("lives-state").textContent = String(Math.max(0, lives));
     document.getElementById("stat-level").textContent = `🏰 ${level}`;
+    document.getElementById("stat-room").textContent = `📍 ${curRx + 1}/${RG_COLS}, ${curRy + 1}/${RG_ROWS}`;
   }
 
   function showOverlay(title, text, btnLabel) {
@@ -597,11 +658,11 @@
         queuedDir = null;
       }
       updateMovement(player, PLAYER_MOVE_MS, now);
-      for (const e of enemies) updateMovement(e, ENEMY_MOVE_MS * 0.9, now);
+      for (const e of activeRoom.devils) updateMovement(e, ENEMY_MOVE_MS * 0.9, now);
 
       if (now - lastEnemyTick > ENEMY_MOVE_MS) {
         lastEnemyTick = now;
-        for (const e of enemies) {
+        for (const e of activeRoom.devils) {
           if (!e.moving) enemyStep(e);
         }
       }

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -641,7 +641,9 @@
     document.getElementById("key-state").textContent = player && player.hasKey ? "✔" : "?";
     document.getElementById("lives-state").textContent = String(Math.max(0, lives));
     document.getElementById("stat-level").textContent = `🏰 ${level}`;
-    document.getElementById("stat-room").textContent = `📍 ${curRx + 1}/${RG_COLS}, ${curRy + 1}/${RG_ROWS}`;
+    const roomStat = document.getElementById("stat-room");
+    roomStat.textContent = `📍 kamer ${curRx + 1},${curRy + 1}`;
+    roomStat.title = `Kamer ${curRx + 1},${curRy + 1} in een raster van ${RG_COLS}×${RG_ROWS} kamers`;
   }
 
   function showOverlay(title, text, btnLabel) {

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -1,0 +1,626 @@
+(() => {
+  "use strict";
+
+  // ---------- config ----------
+  const TILE = 34;
+  const ENEMY_MOVE_MS = 450;
+  const PLAYER_MOVE_MS = 130;
+  const INVULN_MS = 1200;
+
+  // room-grid layout: the map is a grid of "slots", each slot hosts one
+  // rectangular room. Rooms are connected to their N/S/E/W neighbours
+  // through short corridors so that "kamers grenzen aan elkaar".
+  const RG_COLS = 4;
+  const RG_ROWS = 3;
+  const SLOT_W = 7; // interior tile width of a slot
+  const SLOT_H = 6; // interior tile height of a slot
+  const EXTRA_CONNECTION_CHANCE = 0.4; // chance a non-tree edge also gets a doorway (loops, extra exits)
+
+  const COLS = RG_COLS * (SLOT_W + 1) + 1;
+  const ROWS = RG_ROWS * (SLOT_H + 1) + 1;
+
+  const WALL = 0;
+  const FLOOR = 1;
+
+  const DIRS = {
+    up: { dx: 0, dy: -1 },
+    down: { dx: 0, dy: 1 },
+    left: { dx: -1, dy: 0 },
+    right: { dx: 1, dy: 0 },
+  };
+
+  const GEM_TYPES = [
+    { name: "gem_blue", value: 10, weight: 30 },
+    { name: "gem_green", value: 15, weight: 25 },
+    { name: "gem_orange", value: 20, weight: 20 },
+    { name: "gem_red", value: 25, weight: 15 },
+    { name: "gem_white", value: 35, weight: 7 },
+    { name: "gem_pink", value: 50, weight: 3 },
+  ];
+
+  const FLOOR_VARIANTS = [
+    { name: "floor_plain", weight: 40 },
+    { name: "floor_pebbles", weight: 20 },
+    { name: "floor_rocks", weight: 15 },
+    { name: "floor_grass", weight: 12 },
+    { name: "floor_cracked1", weight: 6 },
+    { name: "floor_cracked2", weight: 6 },
+    { name: "floor_skull", weight: 1 },
+  ];
+
+  const DECOR_PROPS = ["torch", "skull", "bone", "rock_small", "rock_big", "grass"];
+
+  const SPRITE_NAMES = [
+    "hero_down", "hero_left", "hero_up", "hero_right",
+    "hero_down_walk", "hero_left_walk", "hero_up_walk", "hero_right_walk",
+    "devil_down", "devil_left", "devil_up", "devil_right",
+    "devil_down_walk", "devil_left_walk", "devil_up_walk", "devil_right_walk",
+    "gem_blue", "gem_green", "gem_red", "gem_orange", "gem_white", "gem_pink",
+    "wall_block",
+    "floor_plain", "floor_pebbles", "floor_rocks", "floor_grass",
+    "floor_cracked1", "floor_cracked2", "floor_skull",
+    "door", "key", "rock_small", "rock_big", "bone", "skull", "torch", "grass",
+  ];
+
+  // sprites live in the original maze's assets, no need to duplicate them
+  const SPRITE_BASE = "../maze/sprites/";
+
+  // ---------- helpers ----------
+  function pickWeighted(list) {
+    const total = list.reduce((s, x) => s + x.weight, 0);
+    let r = Math.random() * total;
+    for (const item of list) {
+      if (r < item.weight) return item;
+      r -= item.weight;
+    }
+    return list[list.length - 1];
+  }
+
+  function shuffle(arr) {
+    for (let i = arr.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
+    return arr;
+  }
+
+  function key2(x, y) { return `${x},${y}`; }
+
+  // ---------- asset loading ----------
+  const images = {};
+  function loadImages(names) {
+    return Promise.all(
+      names.map(
+        (name) =>
+          new Promise((resolve) => {
+            const img = new Image();
+            img.onload = () => resolve();
+            img.onerror = () => resolve();
+            img.src = `${SPRITE_BASE}${name}.png`;
+            images[name] = img;
+          })
+      )
+    );
+  }
+
+  // ---------- room-based maze generation ----------
+  function slotX0(rx) { return 1 + rx * (SLOT_W + 1); }
+  function slotX1(rx) { return slotX0(rx) + SLOT_W - 1; }
+  function slotY0(ry) { return 1 + ry * (SLOT_H + 1); }
+  function slotY1(ry) { return slotY0(ry) + SLOT_H - 1; }
+  function centerCol(rx) { return slotX0(rx) + Math.floor((SLOT_W - 1) / 2); }
+  function centerRow(ry) { return slotY0(ry) + Math.floor((SLOT_H - 1) / 2); }
+
+  // a room is a fairly open rectangle, randomly sized, but always
+  // containing its slot's center row/column so neighbouring rooms can
+  // always be joined by a straight corridor at that row/column.
+  function makeRoomRect(rx, ry) {
+    const sx0 = slotX0(rx), sx1 = slotX1(rx);
+    const sy0 = slotY0(ry), sy1 = slotY1(ry);
+    const cc = centerCol(rx), cr = centerRow(ry);
+
+    const w = 3 + Math.floor(Math.random() * 3); // 3..5
+    const h = 3 + Math.floor(Math.random() * 2); // 3..4
+
+    let x0 = cc - Math.floor(Math.random() * w);
+    x0 = Math.max(sx0, Math.min(x0, sx1 - w + 1));
+    let x1 = Math.min(sx1, x0 + w - 1);
+    if (cc < x0) x0 = cc;
+    if (cc > x1) x1 = cc;
+
+    let y0 = cr - Math.floor(Math.random() * h);
+    y0 = Math.max(sy0, Math.min(y0, sy1 - h + 1));
+    let y1 = Math.min(sy1, y0 + h - 1);
+    if (cr < y0) y0 = cr;
+    if (cr > y1) y1 = cr;
+
+    return { x0, y0, x1, y1, rx, ry, exits: [] };
+  }
+
+  function generateMaze() {
+    const grid = Array.from({ length: ROWS }, () => Array(COLS).fill(WALL));
+
+    const rooms = [];
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      const row = [];
+      for (let rx = 0; rx < RG_COLS; rx++) row.push(makeRoomRect(rx, ry));
+      rooms.push(row);
+    }
+
+    for (const row of rooms) {
+      for (const r of row) {
+        for (let y = r.y0; y <= r.y1; y++) {
+          for (let x = r.x0; x <= r.x1; x++) grid[y][x] = FLOOR;
+        }
+      }
+    }
+
+    // union-find over the room grid, to guarantee full connectivity
+    const n = RG_COLS * RG_ROWS;
+    const parent = Array.from({ length: n }, (_, i) => i);
+    function find(i) { while (parent[i] !== i) { parent[i] = parent[parent[i]]; i = parent[i]; } return i; }
+    function union(a, b) { const ra = find(a), rb = find(b); if (ra === rb) return false; parent[ra] = rb; return true; }
+    function idOf(rx, ry) { return ry * RG_COLS + rx; }
+
+    const edges = [];
+    for (let ry = 0; ry < RG_ROWS; ry++) {
+      for (let rx = 0; rx < RG_COLS; rx++) {
+        if (rx < RG_COLS - 1) edges.push({ a: { rx, ry }, b: { rx: rx + 1, ry }, axis: "h" });
+        if (ry < RG_ROWS - 1) edges.push({ a: { rx, ry }, b: { rx, ry: ry + 1 }, axis: "v" });
+      }
+    }
+    shuffle(edges);
+
+    const connections = [];
+    const leftover = [];
+    for (const e of edges) {
+      if (union(idOf(e.a.rx, e.a.ry), idOf(e.b.rx, e.b.ry))) connections.push(e);
+      else leftover.push(e);
+    }
+
+    // a handful of extra doorways: loops and rooms with more than one exit
+    shuffle(leftover);
+    const extraCount = Math.floor(leftover.length * EXTRA_CONNECTION_CHANCE);
+    for (let i = 0; i < extraCount; i++) connections.push(leftover[i]);
+
+    for (const e of connections) {
+      const roomA = rooms[e.a.ry][e.a.rx];
+      const roomB = rooms[e.b.ry][e.b.rx];
+      if (e.axis === "h") {
+        const row = centerRow(e.a.ry);
+        for (let x = roomA.x1 + 1; x <= roomB.x0 - 1; x++) grid[row][x] = FLOOR;
+        roomA.exits.push("east");
+        roomB.exits.push("west");
+      } else {
+        const col = centerCol(e.a.rx);
+        for (let y = roomA.y1 + 1; y <= roomB.y0 - 1; y++) grid[y][col] = FLOOR;
+        roomA.exits.push("south");
+        roomB.exits.push("north");
+      }
+    }
+
+    const start = { x: centerCol(0), y: centerRow(0) };
+    return { grid, start };
+  }
+
+  function bfs(grid, sx, sy) {
+    const dist = Array.from({ length: ROWS }, () => Array(COLS).fill(-1));
+    dist[sy][sx] = 0;
+    const queue = [[sx, sy]];
+    let head = 0;
+    while (head < queue.length) {
+      const [cx, cy] = queue[head++];
+      for (const d of Object.values(DIRS)) {
+        const nx = cx + d.dx;
+        const ny = cy + d.dy;
+        if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) continue;
+        if (grid[ny][nx] !== FLOOR) continue;
+        if (dist[ny][nx] !== -1) continue;
+        dist[ny][nx] = dist[cy][cx] + 1;
+        queue.push([nx, ny]);
+      }
+    }
+    return dist;
+  }
+
+  // ---------- game state ----------
+  let canvas, ctx;
+  let grid, floorVariant, decor;
+  let start, door, keyItem, gems, enemies;
+  let player;
+  let score = 0, lives = 3, level = 1;
+  let gameOver = false, won = false;
+  let lastEnemyTick = 0;
+  let usedCells;
+
+  function farthestCell(dist) {
+    let best = { x: 1, y: 1, d: -1 };
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        if (dist[y][x] > best.d) best = { x, y, d: dist[y][x] };
+      }
+    }
+    return best;
+  }
+
+  function floorCells(dist, minDist = 0) {
+    const cells = [];
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        if (dist[y][x] >= minDist) cells.push({ x, y, d: dist[y][x] });
+      }
+    }
+    return cells;
+  }
+
+  function claim(x, y) {
+    usedCells.add(key2(x, y));
+  }
+  function isFree(x, y) {
+    return !usedCells.has(key2(x, y));
+  }
+
+  function newLevel(carryScore) {
+    const generated = generateMaze();
+    grid = generated.grid;
+    start = generated.start;
+    usedCells = new Set();
+    claim(start.x, start.y);
+
+    const dist = bfs(grid, start.x, start.y);
+    const far = farthestCell(dist);
+    door = { x: far.x, y: far.y, locked: true };
+    claim(door.x, door.y);
+
+    // key: somewhere between 40%-75% of max distance from start
+    const candidates = floorCells(dist, Math.floor(far.d * 0.4)).filter(
+      (c) => c.d <= far.d * 0.8 && isFree(c.x, c.y)
+    );
+    const keyCell = candidates.length
+      ? candidates[Math.floor(Math.random() * candidates.length)]
+      : { x: start.x, y: start.y };
+    keyItem = { x: keyCell.x, y: keyCell.y, collected: false };
+    claim(keyItem.x, keyItem.y);
+
+    // floor texture + decorations per cell
+    floorVariant = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+    decor = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        if (grid[y][x] === FLOOR) {
+          floorVariant[y][x] = pickWeighted(FLOOR_VARIANTS).name;
+        }
+      }
+    }
+    const allFloor = floorCells(dist).filter((c) => isFree(c.x, c.y));
+    shuffle(allFloor);
+    const decorCount = Math.min(30, allFloor.length);
+    for (let i = 0; i < decorCount; i++) {
+      const c = allFloor[i];
+      decor[c.y][c.x] = DECOR_PROPS[Math.floor(Math.random() * DECOR_PROPS.length)];
+    }
+
+    // gems (diamanten), spread across the rooms
+    gems = [];
+    const gemCandidates = allFloor.slice(decorCount, decorCount + 70);
+    const gemCount = Math.min(18 + level * 2, gemCandidates.length);
+    for (let i = 0; i < gemCount; i++) {
+      const c = gemCandidates[i];
+      const type = pickWeighted(GEM_TYPES);
+      gems.push({ x: c.x, y: c.y, type: type.name, value: type.value, collected: false });
+      claim(c.x, c.y);
+    }
+
+    // devils: spawn reasonably far from the player
+    enemies = [];
+    const enemySpots = floorCells(dist, Math.floor(far.d * 0.3)).filter((c) => isFree(c.x, c.y));
+    shuffle(enemySpots);
+    const enemyCount = Math.min(3 + level, 10, enemySpots.length);
+    for (let i = 0; i < enemyCount; i++) {
+      const c = enemySpots[i];
+      enemies.push({
+        x: c.x, y: c.y,
+        px: c.x * TILE, py: c.y * TILE,
+        facing: "down", moving: false, moveStart: 0, from: { x: c.x, y: c.y },
+      });
+    }
+
+    player = {
+      x: start.x, y: start.y,
+      px: start.x * TILE, py: start.y * TILE,
+      facing: "down", moving: false, moveStart: 0, from: { x: start.x, y: start.y },
+      invulnUntil: 0,
+      hasKey: false,
+    };
+
+    score = carryScore ?? score;
+    gameOver = false;
+    won = false;
+    hideOverlay();
+    updateHud();
+
+    canvas.width = COLS * TILE;
+    canvas.height = ROWS * TILE;
+  }
+
+  // ---------- rendering ----------
+  function drawSprite(name, cx, cy, opts = {}) {
+    const img = images[name];
+    if (!img || !img.complete || img.naturalWidth === 0) return;
+    const fit = opts.fit || "contain-bottom";
+    const scale = opts.scale || 1;
+    if (fit === "cover") {
+      ctx.drawImage(img, cx, cy, TILE, TILE);
+      return;
+    }
+    const targetW = TILE * scale;
+    const ratio = img.naturalHeight / img.naturalWidth;
+    const w = targetW;
+    const h = targetW * ratio;
+    const dx = cx + (TILE - w) / 2;
+    let dy;
+    if (fit === "contain-bottom") dy = cy + TILE - h;
+    else dy = cy + (TILE - h) / 2;
+    ctx.drawImage(img, dx, dy, w, h);
+  }
+
+  function render() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    // floor + walls
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        const cx = x * TILE, cy = y * TILE;
+        if (grid[y][x] === FLOOR) {
+          drawSprite(floorVariant[y][x], cx, cy, { fit: "cover" });
+        } else {
+          drawSprite("wall_block", cx, cy, { fit: "cover" });
+        }
+      }
+    }
+
+    // decorations (flush on floor, no bottom anchor needed for small props)
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        if (decor[y][x]) {
+          drawSprite(decor[y][x], x * TILE, y * TILE, { fit: "contain-center", scale: 0.7 });
+        }
+      }
+    }
+
+    // key + door
+    if (!keyItem.collected) drawSprite("key", keyItem.x * TILE, keyItem.y * TILE, { scale: 0.7 });
+    drawSprite("door", door.x * TILE, door.y * TILE, { scale: 0.95 });
+
+    // gems
+    for (const g of gems) {
+      if (!g.collected) drawSprite(g.type, g.x * TILE, g.y * TILE, { scale: 0.65 });
+    }
+
+    // entities sorted by row for pseudo depth
+    const entities = [
+      ...enemies.map((e) => ({ ...e, kind: "devil" })),
+      { ...player, kind: "hero" },
+    ].sort((a, b) => a.py - b.py);
+
+    for (const e of entities) {
+      const walkFrame = e.moving && Math.floor(performance.now() / 150) % 2 === 0 ? "_walk" : "";
+      const blink = e.kind === "hero" && player.invulnUntil > performance.now() && Math.floor(performance.now() / 100) % 2 === 0;
+      if (blink) continue;
+      const sprite = `${e.kind === "hero" ? "hero" : "devil"}_${e.facing}${walkFrame}`;
+      drawSpritePixel(sprite, e.px, e.py);
+    }
+  }
+
+  function drawSpritePixel(name, px, py) {
+    const img = images[name];
+    if (!img || !img.complete || img.naturalWidth === 0) return;
+    const w = TILE;
+    const ratio = img.naturalHeight / img.naturalWidth;
+    const h = w * ratio;
+    const dx = px;
+    const dy = py + TILE - h;
+    ctx.drawImage(img, dx, dy, w, h);
+  }
+
+  // ---------- movement ----------
+  function tryMove(entity, dir) {
+    if (entity.moving) return false;
+    const d = DIRS[dir];
+    const nx = entity.x + d.dx;
+    const ny = entity.y + d.dy;
+    if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) return false;
+    if (grid[ny][nx] !== FLOOR) return false;
+    entity.facing = dir;
+    entity.from = { x: entity.x, y: entity.y };
+    entity.x = nx;
+    entity.y = ny;
+    entity.moving = true;
+    entity.moveStart = performance.now();
+    return true;
+  }
+
+  function updateMovement(entity, durationMs, now) {
+    if (!entity.moving) return;
+    const t = Math.min(1, (now - entity.moveStart) / durationMs);
+    entity.px = entity.from.x * TILE + (entity.x - entity.from.x) * TILE * t;
+    entity.py = entity.from.y * TILE + (entity.y - entity.from.y) * TILE * t;
+    if (t >= 1) {
+      entity.moving = false;
+      entity.px = entity.x * TILE;
+      entity.py = entity.y * TILE;
+    }
+  }
+
+  function enemyStep(enemy) {
+    const dist = bfs(grid, player.x, player.y);
+    const d = dist[enemy.y][enemy.x];
+    let dir = null;
+    if (d !== -1 && d <= 9 && Math.random() < 0.7) {
+      // step toward player: find neighbor with smaller distance
+      let best = null, bestD = d;
+      for (const [name, vec] of Object.entries(DIRS)) {
+        const nx = enemy.x + vec.dx, ny = enemy.y + vec.dy;
+        if (nx < 0 || ny < 0 || nx >= COLS || ny >= ROWS) continue;
+        if (grid[ny][nx] !== FLOOR) continue;
+        if (dist[ny][nx] !== -1 && dist[ny][nx] < bestD) {
+          bestD = dist[ny][nx];
+          best = name;
+        }
+      }
+      dir = best;
+    }
+    if (!dir) {
+      const options = Object.keys(DIRS).filter((name) => {
+        const vec = DIRS[name];
+        const nx = enemy.x + vec.dx, ny = enemy.y + vec.dy;
+        return nx >= 0 && ny >= 0 && nx < COLS && ny < ROWS && grid[ny][nx] === FLOOR;
+      });
+      if (options.length) dir = options[Math.floor(Math.random() * options.length)];
+    }
+    if (dir) tryMove(enemy, dir);
+  }
+
+  function checkCollisions() {
+    if (!keyItem.collected && player.x === keyItem.x && player.y === keyItem.y) {
+      keyItem.collected = true;
+      player.hasKey = true;
+      updateHud();
+    }
+    for (const g of gems) {
+      if (!g.collected && player.x === g.x && player.y === g.y) {
+        g.collected = true;
+        score += g.value;
+        updateHud();
+      }
+    }
+    if (player.x === door.x && player.y === door.y) {
+      if (player.hasKey) {
+        won = true;
+        showOverlay("Level voltooid!", `Je hebt de deur bereikt met ${score} punten.`, "Volgende level");
+      }
+    }
+    if (player.invulnUntil <= performance.now()) {
+      for (const e of enemies) {
+        if (e.x === player.x && e.y === player.y) {
+          hitPlayer();
+          break;
+        }
+      }
+    }
+  }
+
+  function hitPlayer() {
+    lives -= 1;
+    player.invulnUntil = performance.now() + INVULN_MS;
+    updateHud();
+    if (lives <= 0) {
+      gameOver = true;
+      showOverlay("Game Over", `Je werd gepakt door een duivel. Score: ${score}`, "Opnieuw beginnen");
+    } else {
+      player.x = start.x;
+      player.y = start.y;
+      player.px = start.x * TILE;
+      player.py = start.y * TILE;
+      player.moving = false;
+    }
+  }
+
+  // ---------- hud / overlay ----------
+  function updateHud() {
+    document.getElementById("stat-score").textContent = `⭐ ${score}`;
+    document.getElementById("key-state").textContent = player && player.hasKey ? "✔" : "?";
+    document.getElementById("lives-state").textContent = String(Math.max(0, lives));
+    document.getElementById("stat-level").textContent = `🏰 ${level}`;
+  }
+
+  function showOverlay(title, text, btnLabel) {
+    document.getElementById("overlay-title").textContent = title;
+    document.getElementById("overlay-text").textContent = text;
+    document.getElementById("overlay-btn").textContent = btnLabel;
+    document.getElementById("overlay").classList.remove("hidden");
+  }
+  function hideOverlay() {
+    document.getElementById("overlay").classList.add("hidden");
+  }
+
+  // ---------- input ----------
+  const KEY_DIR = {
+    ArrowUp: "up", ArrowDown: "down", ArrowLeft: "left", ArrowRight: "right",
+    w: "up", s: "down", a: "left", d: "right",
+    W: "up", S: "down", A: "left", D: "right",
+  };
+  let queuedDir = null;
+
+  function handleDir(dir) {
+    if (gameOver || won) return;
+    queuedDir = dir;
+  }
+
+  function setupInput() {
+    window.addEventListener("keydown", (e) => {
+      const dir = KEY_DIR[e.key];
+      if (dir) {
+        e.preventDefault();
+        handleDir(dir);
+      }
+    });
+    for (const btn of document.querySelectorAll("#dpad button")) {
+      const dir = btn.dataset.dir;
+      btn.addEventListener("touchstart", (e) => { e.preventDefault(); handleDir(dir); }, { passive: false });
+      btn.addEventListener("mousedown", () => handleDir(dir));
+    }
+    document.getElementById("btn-new").addEventListener("click", () => {
+      level = 1;
+      score = 0;
+      lives = 3;
+      newLevel(0);
+    });
+    document.getElementById("overlay-btn").addEventListener("click", () => {
+      if (won) {
+        level += 1;
+        newLevel(score);
+      } else {
+        level = 1;
+        score = 0;
+        lives = 3;
+        newLevel(0);
+      }
+    });
+  }
+
+  // ---------- main loop ----------
+  function loop(now) {
+    if (!gameOver && !won) {
+      if (queuedDir && !player.moving) {
+        tryMove(player, queuedDir);
+        queuedDir = null;
+      }
+      updateMovement(player, PLAYER_MOVE_MS, now);
+      for (const e of enemies) updateMovement(e, ENEMY_MOVE_MS * 0.9, now);
+
+      if (now - lastEnemyTick > ENEMY_MOVE_MS) {
+        lastEnemyTick = now;
+        for (const e of enemies) {
+          if (!e.moving) enemyStep(e);
+        }
+      }
+      checkCollisions();
+    }
+    render();
+    requestAnimationFrame(loop);
+  }
+
+  // ---------- boot ----------
+  async function main() {
+    canvas = document.getElementById("canvas");
+    ctx = canvas.getContext("2d");
+    ctx.imageSmoothingEnabled = false;
+    setupInput();
+    await loadImages(SPRITE_NAMES);
+    newLevel(0);
+    requestAnimationFrame(loop);
+  }
+
+  main();
+})();

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -644,6 +644,12 @@
         newLevel(0);
       }
     });
+    document.getElementById("btn-help").addEventListener("click", () => {
+      document.getElementById("help-overlay").classList.remove("hidden");
+    });
+    document.getElementById("help-close").addEventListener("click", () => {
+      document.getElementById("help-overlay").classList.add("hidden");
+    });
   }
 
   // ---------- fullscreen ----------
@@ -673,6 +679,77 @@
     updateLabel();
   }
 
+  // Keep the HUD bar tied to the maze's actual on-screen top row (portrait)
+  // or left column (landscape), so it sits inside that row/column instead
+  // of overlapping into the gameplay area next to it. When the maze is
+  // letterboxed on that axis (dead space above it, or to its left) park the
+  // HUD there instead of squeezing into a strip that might be tiny.
+  const HUD_MIN_PX = 30;
+  const HUD_MAX_PX = 52;
+  function setupHudSizing() {
+    const hud = document.getElementById("hud");
+    const stage = document.getElementById("stage");
+    const btnNew = document.getElementById("btn-new");
+    const landscapeMQ = window.matchMedia("(orientation: landscape)");
+    const sync = () => {
+      // canvas.getBoundingClientRect() is the element's full CSS box, not the
+      // letterboxed content rect that object-fit: contain actually paints
+      // into — work out the real visible maze rect ourselves so the HUD
+      // lines up with it regardless of which way it's letterboxed.
+      const box = canvas.getBoundingClientRect();
+      const stageRect = stage.getBoundingClientRect();
+      if (box.height <= 0 || box.width <= 0) return;
+      const contentAspect = canvas.width / canvas.height;
+      const boxAspect = box.width / box.height;
+      let contentW, contentH;
+      if (boxAspect > contentAspect) {
+        contentH = box.height;
+        contentW = contentH * contentAspect;
+      } else {
+        contentW = box.width;
+        contentH = contentW / contentAspect;
+      }
+      const contentLeft = box.left + (box.width - contentW) / 2;
+      const contentTop = box.top + (box.height - contentH) / 2;
+      const isVertical = landscapeMQ.matches;
+
+      hud.classList.toggle("hud-vertical", isVertical);
+      btnNew.textContent = isVertical ? "+" : "Nieuwe kamers";
+      btnNew.title = isVertical ? "Nieuwe kamers" : "";
+
+      if (isVertical) {
+        const leftGap = contentLeft - box.left; // dead letterbox space left of the maze, if any
+        hud.style.width = ""; // let .hud-vertical's width: var(--row) apply
+        hud.style.top = `${contentTop - stageRect.top}px`;
+        hud.style.height = `${contentH}px`;
+        if (leftGap >= HUD_MIN_PX) {
+          const colPx = Math.min(leftGap, HUD_MAX_PX);
+          hud.style.left = `${contentLeft - stageRect.left - colPx}px`;
+          hud.style.setProperty("--row", `${colPx}px`);
+        } else {
+          hud.style.left = `${contentLeft - stageRect.left}px`;
+          hud.style.setProperty("--row", `${contentW / COLS}px`);
+        }
+      } else {
+        const topGap = contentTop - box.top; // dead letterbox space above the maze, if any
+        hud.style.height = ""; // let #hud's height: var(--row) apply
+        hud.style.left = `${contentLeft - stageRect.left}px`;
+        hud.style.width = `${contentW}px`;
+        if (topGap >= HUD_MIN_PX) {
+          const rowPx = Math.min(topGap, HUD_MAX_PX);
+          hud.style.top = `${contentTop - stageRect.top - rowPx}px`;
+          hud.style.setProperty("--row", `${rowPx}px`);
+        } else {
+          hud.style.top = `${contentTop - stageRect.top}px`;
+          hud.style.setProperty("--row", `${contentH / ROWS}px`);
+        }
+      }
+    };
+    new ResizeObserver(sync).observe(canvas);
+    landscapeMQ.addEventListener("change", sync);
+    sync();
+  }
+
   // touch/mouse-drag joystick: touch anywhere on the stage and drag toward
   // an edge to move that direction, for as long as the drag stays deflected.
   function setupJoystick() {
@@ -680,6 +757,7 @@
     const joystick = document.getElementById("joystick");
     const knob = document.getElementById("joystick-knob");
     const overlay = document.getElementById("overlay");
+    const helpOverlay = document.getElementById("help-overlay");
     const MAX_RADIUS = 40;
     const DEAD_ZONE = 12;
 
@@ -694,7 +772,7 @@
     stage.addEventListener("pointerdown", (e) => {
       if (activePointerId !== null) return;
       if (gameOver || won) return;
-      if (!overlay.classList.contains("hidden")) return;
+      if (!overlay.classList.contains("hidden") || !helpOverlay.classList.contains("hidden")) return;
       if (e.target.closest("#hud")) return;
       activePointerId = e.pointerId;
       const rect = stage.getBoundingClientRect();
@@ -763,6 +841,7 @@
     setupJoystick();
     await loadImages(SPRITE_NAMES);
     newLevel(0);
+    setupHudSizing(); // after newLevel() so canvas.width/height reflect the real maze size
     requestAnimationFrame(loop);
   }
 

--- a/app/src/assets/maze-rooms/game.js
+++ b/app/src/assets/maze-rooms/game.js
@@ -127,6 +127,88 @@
     );
   }
 
+  // ---------- sound effects (synthesized, no audio files needed) ----------
+  let audioCtx = null;
+  let muted = localStorage.getItem("maze-rooms-muted") === "1";
+
+  function ensureAudioContext() {
+    if (!audioCtx) {
+      const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+      audioCtx = new AudioContextCtor();
+    }
+    if (audioCtx.state === "suspended") audioCtx.resume();
+    return audioCtx;
+  }
+
+  // Schedules a single tone at `startOffset` seconds from now with a quick
+  // attack/decay envelope so notes click in cleanly and taper off instead of
+  // popping when they stop.
+  function scheduleTone(freq, startOffset, duration, { type = "triangle", volume = 0.18 } = {}) {
+    if (muted || !audioCtx) return;
+    const t0 = audioCtx.currentTime + startOffset;
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = type;
+    osc.frequency.setValueAtTime(freq, t0);
+    gain.gain.setValueAtTime(0.0001, t0);
+    gain.gain.exponentialRampToValueAtTime(volume, t0 + 0.012);
+    gain.gain.exponentialRampToValueAtTime(0.0001, t0 + duration);
+    osc.connect(gain).connect(audioCtx.destination);
+    osc.start(t0);
+    osc.stop(t0 + duration + 0.02);
+    return osc;
+  }
+
+  // gem value -> pitch on an ascending scale, so rarer/pricier gems ring out
+  // higher and brighter than common ones.
+  const GEM_PITCH_BY_VALUE = { 10: 523, 15: 587, 20: 659, 25: 784, 35: 880, 50: 1047 };
+
+  const sfx = {
+    gem(value) {
+      if (!audioCtx) return;
+      const freq = GEM_PITCH_BY_VALUE[value] || 700;
+      scheduleTone(freq, 0, 0.14, { type: "triangle", volume: 0.2 });
+      if (value >= 35) scheduleTone(freq * 1.5, 0.05, 0.12, { type: "triangle", volume: 0.14 });
+    },
+    key() {
+      if (!audioCtx) return;
+      scheduleTone(660, 0, 0.12, { type: "triangle", volume: 0.2 });
+      scheduleTone(990, 0.1, 0.18, { type: "triangle", volume: 0.22 });
+    },
+    hit() {
+      if (!audioCtx) return;
+      scheduleTone(140, 0, 0.22, { type: "sawtooth", volume: 0.22 });
+      scheduleTone(90, 0.05, 0.2, { type: "sawtooth", volume: 0.18 });
+    },
+    win() {
+      if (!audioCtx) return;
+      [523, 659, 784, 1047].forEach((freq, i) => {
+        scheduleTone(freq, i * 0.11, 0.16, { type: "triangle", volume: 0.2 });
+      });
+    },
+    gameOver() {
+      if (!audioCtx) return;
+      [392, 330, 262].forEach((freq, i) => {
+        scheduleTone(freq, i * 0.22, 0.3, { type: "sawtooth", volume: 0.18 });
+      });
+    },
+  };
+
+  function setupMute() {
+    const btn = document.getElementById("btn-mute");
+    const updateLabel = () => {
+      btn.textContent = muted ? "🔇" : "🔊";
+      btn.title = muted ? "Geluid aan" : "Geluid uit";
+    };
+    btn.addEventListener("click", () => {
+      muted = !muted;
+      localStorage.setItem("maze-rooms-muted", muted ? "1" : "0");
+      if (!muted) ensureAudioContext();
+      updateLabel();
+    });
+    updateLabel();
+  }
+
   // ---------- room-graph (which rooms connect to which, and where) ----------
   function buildRoomGraph() {
     const n = RG_COLS * RG_ROWS;
@@ -589,17 +671,20 @@
     if (room.hasKey && !room.keyCollected && player.x === room.keyPos.x && player.y === room.keyPos.y) {
       room.keyCollected = true;
       player.hasKey = true;
+      sfx.key();
       updateHud();
     }
     for (const g of room.gems) {
       if (!g.collected && player.x === g.x && player.y === g.y) {
         g.collected = true;
         score += g.value;
+        sfx.gem(g.value);
         updateHud();
       }
     }
     if (room.hasDoor && player.x === room.doorPos.x && player.y === room.doorPos.y && player.hasKey) {
       won = true;
+      sfx.win();
       showOverlay("Level voltooid!", `Je hebt de deur bereikt met ${score} punten.`, "Volgende level");
     }
     if (player.invulnUntil <= performance.now()) {
@@ -618,9 +703,11 @@
   function hitPlayer() {
     lives -= 1;
     player.invulnUntil = performance.now() + INVULN_MS;
+    sfx.hit();
     updateHud();
     if (lives <= 0) {
       gameOver = true;
+      sfx.gameOver();
       showOverlay("Game Over", `Je werd gepakt door een duivel. Score: ${score}`, "Opnieuw beginnen");
     } else {
       curRx = 0;
@@ -680,6 +767,7 @@
       const dir = KEY_DIR[e.key];
       if (dir) {
         e.preventDefault();
+        if (!muted) ensureAudioContext(); // unlock audio from this real user gesture
         heldDirs.add(dir);
       }
     });
@@ -834,6 +922,7 @@
     }
 
     stage.addEventListener("pointerdown", (e) => {
+      if (!muted) ensureAudioContext(); // unlock audio from this real user gesture
       if (activePointerId !== null) return;
       if (gameOver || won) return;
       if (!overlay.classList.contains("hidden") || !helpOverlay.classList.contains("hidden")) return;
@@ -900,6 +989,7 @@
     setupInput();
     setupFullscreen();
     setupJoystick();
+    setupMute();
     await loadImages(SPRITE_NAMES);
     newLevel(0);
     setupHudSizing(); // after newLevel() so canvas.width/height reflect the real maze size

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -15,6 +15,7 @@
         <span class="stat" id="stat-key">🔑 <span id="key-state">?</span></span>
         <span class="stat" id="stat-lives">❤️ <span id="lives-state">3</span></span>
         <span class="stat" id="stat-level">🏰 1</span>
+        <span class="stat" id="stat-room">📍 1/4, 1/3</span>
       </div>
       <button id="btn-new">Nieuwe kamers</button>
     </header>
@@ -39,7 +40,7 @@
       </div>
     </div>
 
-    <p id="hint">Beweeg met pijltjestoetsen / WASD door de kamers. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
+    <p id="hint">Beweeg met pijltjestoetsen / WASD. Loop door de rand van het scherm naar de volgende kamer. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
   </div>
 
   <script src="game.js"></script>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -32,6 +32,11 @@
         <div id="joystick-knob"></div>
       </div>
 
+      <div id="orientation-hint">
+        <span>Best played full screen landscape orientation</span>
+        <button id="orientation-hint-close" title="Sluiten" aria-label="Sluiten">×</button>
+      </div>
+
       <div id="overlay" class="modal hidden">
         <div class="modal-card">
           <h2 id="overlay-title"></h2>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+  <title>Dungeon Maze - Kamers</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div id="game">
+    <header id="hud">
+      <h1>Dungeon Maze - Kamers</h1>
+      <div class="stats">
+        <span class="stat" id="stat-score">⭐ 0</span>
+        <span class="stat" id="stat-key">🔑 <span id="key-state">?</span></span>
+        <span class="stat" id="stat-lives">❤️ <span id="lives-state">3</span></span>
+        <span class="stat" id="stat-level">🏰 1</span>
+      </div>
+      <button id="btn-new">Nieuwe kamers</button>
+    </header>
+
+    <div id="stage">
+      <canvas id="canvas"></canvas>
+      <div id="overlay" class="hidden">
+        <div id="overlay-card">
+          <h2 id="overlay-title"></h2>
+          <p id="overlay-text"></p>
+          <button id="overlay-btn">Opnieuw</button>
+        </div>
+      </div>
+    </div>
+
+    <div id="dpad">
+      <button data-dir="up">▲</button>
+      <div class="dpad-row">
+        <button data-dir="left">◀</button>
+        <button data-dir="down">▼</button>
+        <button data-dir="right">▶</button>
+      </div>
+    </div>
+
+    <p id="hint">Beweeg met pijltjestoetsen / WASD door de kamers. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
+  </div>
+
+  <script src="game.js"></script>
+</body>
+</html>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -8,36 +8,46 @@
 </head>
 <body>
   <div id="game">
-    <header id="hud">
-      <h1>Dungeon Maze - Kamers</h1>
-      <div class="stats">
-        <span class="stat" id="stat-score">⭐ 0</span>
-        <span class="stat" id="stat-key">🔑 <span id="key-state">?</span></span>
-        <span class="stat" id="stat-lives">❤️ <span id="lives-state">3</span></span>
-        <span class="stat" id="stat-level">🏰 1</span>
-        <span class="stat" id="stat-room">📍 1/4, 1/3</span>
-      </div>
-      <div class="hud-buttons">
-        <button id="btn-fullscreen" title="Fullscreen">⛶</button>
-        <button id="btn-new">Nieuwe kamers</button>
-      </div>
-    </header>
-
     <div id="stage">
       <canvas id="canvas"></canvas>
+
+      <header id="hud">
+        <h1>Dungeon Maze - Kamers</h1>
+        <div class="stats">
+          <span class="stat" id="stat-score">⭐ 0</span>
+          <span class="stat" id="stat-key">🔑 <span id="key-state">?</span></span>
+          <span class="stat" id="stat-lives">❤️ <span id="lives-state">3</span></span>
+          <span class="stat" id="stat-level">🏰 1</span>
+          <span class="stat" id="stat-room">📍 1/4, 1/3</span>
+        </div>
+        <div class="hud-buttons">
+          <button id="btn-help" title="Uitleg">?</button>
+          <button id="btn-fullscreen" title="Fullscreen">⛶</button>
+          <button id="btn-new">Nieuwe kamers</button>
+        </div>
+      </header>
+
       <div id="joystick" class="hidden">
         <div id="joystick-knob"></div>
       </div>
-      <div id="overlay" class="hidden">
-        <div id="overlay-card">
+
+      <div id="overlay" class="modal hidden">
+        <div class="modal-card">
           <h2 id="overlay-title"></h2>
           <p id="overlay-text"></p>
           <button id="overlay-btn">Opnieuw</button>
         </div>
       </div>
-    </div>
 
-    <p id="hint">Beweeg met pijltjestoetsen / WASD, of raak het scherm aan en sleep om te bewegen. Loop door de rand van het scherm naar de volgende kamer. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
+      <div id="help-overlay" class="modal hidden">
+        <div class="modal-card">
+          <h2>Hoe speel je</h2>
+          <p>Raak het scherm ergens aan en sleep naar links/rechts/boven/onder om te bewegen (of gebruik pijltjestoetsen / WASD).</p>
+          <p>Vind de sleutel 🔑 en verzamel diamanten. Loop door de rand van het scherm om naar de volgende kamer te gaan, en bereik de deur voordat de duivels je pakken.</p>
+          <button id="help-close">Sluiten</button>
+        </div>
+      </div>
+    </div>
   </div>
 
   <script src="game.js"></script>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -17,11 +17,17 @@
         <span class="stat" id="stat-level">🏰 1</span>
         <span class="stat" id="stat-room">📍 1/4, 1/3</span>
       </div>
-      <button id="btn-new">Nieuwe kamers</button>
+      <div class="hud-buttons">
+        <button id="btn-fullscreen" title="Fullscreen">⛶</button>
+        <button id="btn-new">Nieuwe kamers</button>
+      </div>
     </header>
 
     <div id="stage">
       <canvas id="canvas"></canvas>
+      <div id="joystick" class="hidden">
+        <div id="joystick-knob"></div>
+      </div>
       <div id="overlay" class="hidden">
         <div id="overlay-card">
           <h2 id="overlay-title"></h2>
@@ -31,16 +37,7 @@
       </div>
     </div>
 
-    <div id="dpad">
-      <button data-dir="up">▲</button>
-      <div class="dpad-row">
-        <button data-dir="left">◀</button>
-        <button data-dir="down">▼</button>
-        <button data-dir="right">▶</button>
-      </div>
-    </div>
-
-    <p id="hint">Beweeg met pijltjestoetsen / WASD. Loop door de rand van het scherm naar de volgende kamer. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
+    <p id="hint">Beweeg met pijltjestoetsen / WASD, of raak het scherm aan en sleep om te bewegen. Loop door de rand van het scherm naar de volgende kamer. Vind de sleutel 🔑, verzamel diamanten en bereik de deur voordat de duivels je pakken.</p>
   </div>
 
   <script src="game.js"></script>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -18,7 +18,7 @@
           <span class="stat" id="stat-key">🔑 <span id="key-state">?</span></span>
           <span class="stat" id="stat-lives">❤️ <span id="lives-state">3</span></span>
           <span class="stat" id="stat-level">🏰 1</span>
-          <span class="stat" id="stat-room">📍 1/4, 1/3</span>
+          <span class="stat" id="stat-room" title="Je huidige kamer in het kamerraster">📍 kamer 1,1</span>
         </div>
         <div class="hud-buttons">
           <button id="btn-help" title="Uitleg">?</button>
@@ -43,7 +43,7 @@
         <div class="modal-card">
           <h2>Hoe speel je</h2>
           <p>Raak het scherm ergens aan en sleep naar links/rechts/boven/onder om te bewegen (of gebruik pijltjestoetsen / WASD).</p>
-          <p>Vind de sleutel 🔑 en verzamel diamanten. Loop door de rand van het scherm om naar de volgende kamer te gaan, en bereik de deur voordat de duivels je pakken.</p>
+          <p>Vind de sleutel 🔑 en verzamel diamanten. Loop door de rand van het scherm om naar de volgende kamer te gaan, en bereik de deur voordat de duivels je pakken. De 📍 laat zien in welke kamer van het raster je nu bent.</p>
           <button id="help-close">Sluiten</button>
         </div>
       </div>

--- a/app/src/assets/maze-rooms/index.html
+++ b/app/src/assets/maze-rooms/index.html
@@ -21,6 +21,7 @@
           <span class="stat" id="stat-room" title="Je huidige kamer in het kamerraster">📍 kamer 1,1</span>
         </div>
         <div class="hud-buttons">
+          <button id="btn-mute" title="Geluid uit">🔊</button>
           <button id="btn-help" title="Uitleg">?</button>
           <button id="btn-fullscreen" title="Fullscreen">⛶</button>
           <button id="btn-new">Nieuwe kamers</button>

--- a/app/src/assets/maze-rooms/style.css
+++ b/app/src/assets/maze-rooms/style.css
@@ -217,3 +217,45 @@ html, body {
   background: rgba(232, 179, 74, 0.55);
   border: 2px solid rgba(232, 179, 74, 0.8);
 }
+
+/* ---------- portrait-orientation hint ---------- */
+
+#orientation-hint {
+  position: absolute;
+  left: 50%;
+  bottom: 16px;
+  transform: translateX(-50%);
+  z-index: 25;
+  display: none;
+  align-items: center;
+  gap: 10px;
+  background: rgba(23, 28, 43, 0.95);
+  border: 1px solid #3a4260;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text);
+  max-width: 88%;
+  text-align: center;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+@media (orientation: portrait) {
+  #orientation-hint { display: flex; }
+}
+
+#orientation-hint.dismissed { display: none !important; }
+
+#orientation-hint button {
+  background: transparent;
+  border: 1px solid #3a4260;
+  border-radius: 6px;
+  color: var(--text);
+  font-size: 0.95rem;
+  line-height: 1;
+  padding: 2px 8px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+#orientation-hint button:hover { filter: brightness(1.2); }

--- a/app/src/assets/maze-rooms/style.css
+++ b/app/src/assets/maze-rooms/style.css
@@ -135,7 +135,7 @@ html, body {
 
 #btn-new:hover, .modal-card button:hover { filter: brightness(1.1); }
 
-#btn-fullscreen, #btn-help {
+#btn-fullscreen, #btn-help, #btn-mute {
   background: var(--panel);
   color: var(--text);
   border: 1px solid #3a4260;
@@ -146,7 +146,7 @@ html, body {
   cursor: pointer;
 }
 
-#btn-fullscreen:hover, #btn-help:hover { filter: brightness(1.2); }
+#btn-fullscreen:hover, #btn-help:hover, #btn-mute:hover { filter: brightness(1.2); }
 
 @media (max-width: 480px) {
   #hud h1 { display: none; }

--- a/app/src/assets/maze-rooms/style.css
+++ b/app/src/assets/maze-rooms/style.css
@@ -1,0 +1,150 @@
+:root {
+  --bg: #0b0f1a;
+  --panel: #171c2b;
+  --accent: #e8b34a;
+  --text: #e9ecf5;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  margin: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "Segoe UI", system-ui, sans-serif;
+}
+
+#game {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+#hud {
+  width: 100%;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background: var(--panel);
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 1px solid #2a3145;
+}
+
+#hud h1 {
+  font-size: 1.1rem;
+  margin: 0;
+  color: var(--accent);
+  letter-spacing: 0.5px;
+}
+
+.stats {
+  display: flex;
+  gap: 14px;
+  font-size: 0.95rem;
+}
+
+.stat { white-space: nowrap; }
+
+#btn-new, #overlay-btn {
+  background: var(--accent);
+  color: #1a1508;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#btn-new:hover, #overlay-btn:hover { filter: brightness(1.1); }
+
+#stage {
+  position: relative;
+  border: 3px solid #2a3145;
+  border-radius: 8px;
+  overflow: hidden;
+  line-height: 0;
+  max-width: 100%;
+}
+
+#canvas {
+  display: block;
+  image-rendering: pixelated;
+  background: #05070c;
+  max-width: 100%;
+  height: auto;
+}
+
+#overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(5, 7, 12, 0.82);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#overlay.hidden { display: none; }
+
+#overlay-card {
+  text-align: center;
+  padding: 24px 32px;
+  background: var(--panel);
+  border: 1px solid #3a4260;
+  border-radius: 12px;
+}
+
+#overlay-title {
+  margin: 0 0 8px;
+  font-size: 1.6rem;
+}
+
+#overlay-text {
+  margin: 0 0 16px;
+  color: #c7cce0;
+}
+
+#dpad {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  user-select: none;
+}
+
+#dpad .dpad-row {
+  display: flex;
+  gap: 4px;
+}
+
+#dpad button {
+  width: 52px;
+  height: 52px;
+  font-size: 1.2rem;
+  border-radius: 8px;
+  border: 1px solid #3a4260;
+  background: var(--panel);
+  color: var(--text);
+  cursor: pointer;
+}
+
+#dpad button:active { background: var(--accent); color: #1a1508; }
+
+#hint {
+  max-width: 640px;
+  text-align: center;
+  color: #9aa2bd;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+@media (min-width: 700px) {
+  #dpad { display: none; }
+}

--- a/app/src/assets/maze-rooms/style.css
+++ b/app/src/assets/maze-rooms/style.css
@@ -7,22 +7,33 @@
 
 * { box-sizing: border-box; }
 
+.hidden { display: none; }
+
 html, body {
   margin: 0;
   height: 100%;
   background: var(--bg);
   color: var(--text);
   font-family: "Segoe UI", system-ui, sans-serif;
+  overflow: hidden;
 }
 
 #game {
   max-width: 1000px;
+  height: 100dvh;
   margin: 0 auto;
   padding: 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 12px;
+}
+
+#game:fullscreen {
+  max-width: 100%;
+  width: 100%;
+  height: 100%;
+  background: var(--bg);
 }
 
 #hud {
@@ -53,6 +64,12 @@ html, body {
 
 .stat { white-space: nowrap; }
 
+.hud-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 #btn-new, #overlay-btn {
   background: var(--accent);
   color: #1a1508;
@@ -65,21 +82,38 @@ html, body {
 
 #btn-new:hover, #overlay-btn:hover { filter: brightness(1.1); }
 
+#btn-fullscreen {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid #3a4260;
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+#btn-fullscreen:hover { filter: brightness(1.2); }
+
 #stage {
   position: relative;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
   border: 3px solid #2a3145;
   border-radius: 8px;
   overflow: hidden;
-  line-height: 0;
-  max-width: 100%;
+  touch-action: none;
 }
 
 #canvas {
-  display: block;
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
   image-rendering: pixelated;
   background: #05070c;
-  max-width: 100%;
-  height: auto;
 }
 
 #overlay {
@@ -89,6 +123,7 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: center;
+  z-index: 30;
 }
 
 #overlay.hidden { display: none; }
@@ -111,31 +146,33 @@ html, body {
   color: #c7cce0;
 }
 
-#dpad {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 4px;
-  user-select: none;
+/* ---------- floating drag joystick ---------- */
+
+#joystick {
+  position: absolute;
+  width: 96px;
+  height: 96px;
+  margin-left: -48px;
+  margin-top: -48px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  z-index: 15;
+  pointer-events: none;
 }
 
-#dpad .dpad-row {
-  display: flex;
-  gap: 4px;
+#joystick-knob {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 44px;
+  height: 44px;
+  margin-left: -22px;
+  margin-top: -22px;
+  border-radius: 50%;
+  background: rgba(232, 179, 74, 0.55);
+  border: 2px solid rgba(232, 179, 74, 0.8);
 }
-
-#dpad button {
-  width: 52px;
-  height: 52px;
-  font-size: 1.2rem;
-  border-radius: 8px;
-  border: 1px solid #3a4260;
-  background: var(--panel);
-  color: var(--text);
-  cursor: pointer;
-}
-
-#dpad button:active { background: var(--accent); color: #1a1508; }
 
 #hint {
   max-width: 640px;
@@ -143,8 +180,4 @@ html, body {
   color: #9aa2bd;
   font-size: 0.85rem;
   margin: 0;
-}
-
-@media (min-width: 700px) {
-  #dpad { display: none; }
 }

--- a/app/src/assets/maze-rooms/style.css
+++ b/app/src/assets/maze-rooms/style.css
@@ -22,11 +22,9 @@ html, body {
   max-width: 1000px;
   height: 100dvh;
   margin: 0 auto;
-  padding: 16px;
+  padding: 8px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 12px;
 }
 
 #game:fullscreen {
@@ -36,70 +34,10 @@ html, body {
   background: var(--bg);
 }
 
-#hud {
-  width: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 10px;
-  background: var(--panel);
-  padding: 10px 16px;
-  border-radius: 10px;
-  border: 1px solid #2a3145;
-}
-
-#hud h1 {
-  font-size: 1.1rem;
-  margin: 0;
-  color: var(--accent);
-  letter-spacing: 0.5px;
-}
-
-.stats {
-  display: flex;
-  gap: 14px;
-  font-size: 0.95rem;
-}
-
-.stat { white-space: nowrap; }
-
-.hud-buttons {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-#btn-new, #overlay-btn {
-  background: var(--accent);
-  color: #1a1508;
-  border: none;
-  border-radius: 6px;
-  padding: 8px 14px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-#btn-new:hover, #overlay-btn:hover { filter: brightness(1.1); }
-
-#btn-fullscreen {
-  background: var(--panel);
-  color: var(--text);
-  border: 1px solid #3a4260;
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 0.95rem;
-  line-height: 1;
-  cursor: pointer;
-}
-
-#btn-fullscreen:hover { filter: brightness(1.2); }
-
 #stage {
   position: relative;
   flex: 1;
   min-height: 0;
-  width: 100%;
   border: 3px solid #2a3145;
   border-radius: 8px;
   overflow: hidden;
@@ -116,7 +54,109 @@ html, body {
   background: #05070c;
 }
 
-#overlay {
+/* ---------- HUD (overlaid on the canvas, not in normal flow) ---------- */
+
+#hud {
+  --row: 40px; /* kept in sync with the maze's actual on-screen top row by JS */
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0; /* left/width overridden inline to track the canvas's letterboxed rect */
+  height: var(--row);
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: calc(var(--row) * 0.2);
+  background: rgba(11, 15, 26, 0.78);
+  backdrop-filter: blur(2px);
+  padding: 0 calc(var(--row) * 0.22);
+  font-size: calc(var(--row) * 0.34);
+  overflow: hidden;
+  white-space: nowrap;
+  pointer-events: none; /* let drags pass through the empty gaps between controls */
+}
+
+#hud > * { pointer-events: auto; }
+
+/* landscape: run down the left edge instead of across the top */
+#hud.hud-vertical {
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  width: var(--row);
+  height: 0; /* top/height overridden inline to track the maze's left column */
+  padding: calc(var(--row) * 0.22) 0;
+  gap: calc(var(--row) * 0.22);
+}
+
+#hud.hud-vertical .stats { flex-direction: column; gap: 0.55em; }
+#hud.hud-vertical .hud-buttons { flex-direction: column; gap: 0.35em; }
+
+#hud h1 {
+  font-size: 1em;
+  margin: 0;
+  color: var(--accent);
+  letter-spacing: 0.5px;
+}
+
+.stats {
+  display: flex;
+  gap: 0.8em;
+  font-size: 0.88em;
+}
+
+.stat { white-space: nowrap; }
+
+.hud-buttons {
+  display: flex;
+  gap: 0.35em;
+}
+
+#btn-new, .modal-card button {
+  background: var(--accent);
+  color: #1a1508;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#btn-new {
+  border-radius: 0.3em;
+  padding: 0.3em 0.55em;
+  font-size: 0.8em;
+}
+
+.modal-card button {
+  padding: 8px 14px;
+  font-size: 1rem;
+}
+
+#btn-new:hover, .modal-card button:hover { filter: brightness(1.1); }
+
+#btn-fullscreen, #btn-help {
+  background: var(--panel);
+  color: var(--text);
+  border: 1px solid #3a4260;
+  border-radius: 0.3em;
+  padding: 0.25em 0.5em;
+  font-size: 0.85em;
+  line-height: 1;
+  cursor: pointer;
+}
+
+#btn-fullscreen:hover, #btn-help:hover { filter: brightness(1.2); }
+
+@media (max-width: 480px) {
+  #hud h1 { display: none; }
+}
+
+#hud.hud-vertical h1 { display: none; }
+
+/* ---------- shared modal (game-state overlay + help panel) ---------- */
+
+.modal {
   position: absolute;
   inset: 0;
   background: rgba(5, 7, 12, 0.82);
@@ -126,25 +166,29 @@ html, body {
   z-index: 30;
 }
 
-#overlay.hidden { display: none; }
+.modal.hidden { display: none; }
 
-#overlay-card {
+.modal-card {
   text-align: center;
   padding: 24px 32px;
+  max-width: min(90%, 420px);
   background: var(--panel);
   border: 1px solid #3a4260;
   border-radius: 12px;
 }
 
-#overlay-title {
+.modal-card h2 {
   margin: 0 0 8px;
   font-size: 1.6rem;
 }
 
-#overlay-text {
-  margin: 0 0 16px;
+.modal-card p {
+  margin: 0 0 12px;
   color: #c7cce0;
+  font-size: 0.9rem;
 }
+
+.modal-card button { margin-top: 4px; }
 
 /* ---------- floating drag joystick ---------- */
 
@@ -172,12 +216,4 @@ html, body {
   border-radius: 50%;
   background: rgba(232, 179, 74, 0.55);
   border: 2px solid rgba(232, 179, 74, 0.8);
-}
-
-#hint {
-  max-width: 640px;
-  text-align: center;
-  color: #9aa2bd;
-  font-size: 0.85rem;
-  margin: 0;
 }


### PR DESCRIPTION
## Summary
- Adds a new maze variant ("Dungeon Maze - Kamers") where each room fills the whole screen and has 1-4 exits oriented N/S/E/W. Walking through an exit off the edge of the screen loads the neighbouring room, entering from the opposite edge — a classic Zelda-style room-to-room layout instead of one large corridor map.
- The world is a 4x3 grid of rooms connected via a randomized spanning tree (plus a few extra edges for loops/multiple exits), guaranteeing every room is reachable. Verified with 1000 generated worlds in a standalone script (0 unreachable rooms).
- Key/door/gems/devils reuse the existing gameplay loop: find the key, reach the goal door, avoid the devils, collect diamonds. Placement now uses graph distance between rooms (since there's no single connected tile grid), and each room's content persists as you move in and out.
- Wires the new variant into the Angular app: route (`/maze-rooms`), component, and a homepage card, following the same pattern the existing Dungeon Maze integration uses (which was added on `main` in parallel with this branch).
- Rebased onto `main` and fixed sprite references broken by `main`'s independent rework of the original maze (`wall_block` -> `wall_fill`, removed `hero_*_walk` frames).

## Test plan
- [x] `ng build` succeeds
- [x] Standalone Node script generated 1000 room-graph worlds: always fully connected, exit counts per room in range 1-4, no corner/edge tile bugs
- [x] Verified in a real browser (Playwright): homepage shows both maze cards, `/maze-rooms` route renders inside the app with working movement, collisions, gem pickup, and room-to-room transitions via the screen edge
- [x] Verified the original `/maze` route still renders correctly (no console errors, no 404s on sprites) after the rebase
